### PR TITLE
Update get_started.md

### DIFF
--- a/templates/get_started.md
+++ b/templates/get_started.md
@@ -36,7 +36,9 @@ then you can try one of our autonomous bundles for:
 Each of these bundles contains a folder `trylean` from which you can run
 the program `trylean` without installing anything anywhere else on your
 computer (although MacOS users will need to tell their system
-they really want to run it). These bundles contain Lean itself,
+they really want to run it). On Windows this is a batch file, and there will be a Microsoft 
+Defender warning when running it. To allow the batch file to execute, click on "More Info" 
+then "Run anyway". These bundles contain Lean itself,
 [VScodium](https://vscodium.com/)
 which is a distributable version of the VS Code editor, the Lean VS Code extension,
 the mathlib library, and a couple of Lean files to play with.


### PR DESCRIPTION
Added a bit on how to run on Windows. 

I'm not sure about this to be honest. The process is probably simpler than on MacOS (at least the last time I used MacOS), yet the description for MacOS is just "(although MacOS users will need to tell their system they really want to run it)". If you're expecting users to have that level of technical competence, then changing `MacOS` to `Windows/MacOS` would suffice, and the extra sentence isn't necessary.

Also I did this on the online editor without rulers, sorry if the line is too long.