### PR TITLE
make markdown headings linkable

### DIFF
--- a/css/lean.css
+++ b/css/lean.css
@@ -9997,7 +9997,3 @@ li.nav-item.dropdown:hover .dropdown-menu {
 .markdown-heading:hover > .hover-link {
   display: inline;
 }
-
-.hover-link:hover {
-  text-decoration: underline;
-}

--- a/css/lean.css
+++ b/css/lean.css
@@ -9989,3 +9989,15 @@ li.nav-item.dropdown:hover .dropdown-menu {
   margin-top: -1px !important;
   /* When the dropdown comes down on hover, this will make it easier to get to the dropdown contents without losing it. */
 }
+
+.hover-link {
+  display: none;
+}
+
+.markdown-heading:hover > .hover-link {
+  display: inline;
+}
+
+.hover-link:hover {
+  text-decoration: underline;
+}

--- a/make_site.py
+++ b/make_site.py
@@ -19,7 +19,7 @@ class CustomHTMLRenderer(HTMLRenderer):
     Override the default heading to provide links like in GitHub.
     """
     def render_heading(self, token) -> str:
-        template = '<h{level} id="{anchor}"><a href="#{anchor}">#</a> {inner}</h{level}>'
+        template = '<h{level} id="{anchor}" class="markdown-heading">{inner} <a class="hover-link" href="#{anchor}">#</a></h{level}>'
         inner: str = self.render_inner(token)
         # generate anchor following what github does
         # See info and links at https://gist.github.com/asabaylus/3071099

--- a/scss/lean.scss
+++ b/scss/lean.scss
@@ -18,4 +18,14 @@ li.nav-item.dropdown:hover .dropdown-menu {
   margin-top: -1px !important; /* When the dropdown comes down on hover, this will make it easier to get to the dropdown contents without losing it. */
 }
 
+.hover-link {
+  display: none;
+}
 
+.markdown-heading:hover > .hover-link {
+  display: inline;
+}
+
+.hover-link:hover {
+  text-decoration: underline;
+}

--- a/scss/lean.scss
+++ b/scss/lean.scss
@@ -25,7 +25,3 @@ li.nav-item.dropdown:hover .dropdown-menu {
 .markdown-heading:hover > .hover-link {
   display: inline;
 }
-
-.hover-link:hover {
-  text-decoration: underline;
-}


### PR DESCRIPTION
This PR makes markdown headings linkable like the way they are on github. Currently it's set up to look like this (adding a `#` symbol to the left):

<img width="535" alt="Screenshot 2020-05-13 22 32 32" src="https://user-images.githubusercontent.com/5209952/81886026-acb6fe80-9569-11ea-80fa-171dad5a1fac.png">

If this is too ugly, it shouldn't be too hard to change the template.