### PR TITLE
add "Suggest edits to this page on GitHub" to bottom of markdown pages

### DIFF
--- a/css/lean.css
+++ b/css/lean.css
@@ -9973,6 +9973,20 @@ h3 {
     border-color: #dee2e6;
   }
 }
+html {
+  height: 100%;
+}
+
+body {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+body > #wrapper {
+  flex-grow: 1;
+}
+
 code {
   color: #931e53;
 }

--- a/make_site.py
+++ b/make_site.py
@@ -174,7 +174,7 @@ def render_site(target: Path, base_url: str, reloader=False):
 
     def get_contents(template):
         return { 'content': Path(template.filename).read_text(encoding='utf-8').replace('img/',
-            base_url+'/img/') }
+            base_url+'/img/'), 'name': template.name }
 
     def url(raw: str):
         return raw if raw.startswith('http') else base_url + raw

--- a/scss/lean.scss
+++ b/scss/lean.scss
@@ -2,6 +2,22 @@ $enable-gradients:                            true;
 $enable-shadows : true;
 @import "../bootstrap-4.4.1/scss/bootstrap";
 
+// push the footer to the bottom of the screen
+// https://stackoverflow.com/a/54100290
+html {
+  height: 100%;
+}
+
+body {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+body > #wrapper {
+  flex-grow: 1;
+}
+
 code {
   color: #931e53
 }

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -58,8 +58,15 @@
   </nav>
   <div class="container-sm mt-4">
 	  {% block content %}
-	  {% endblock %}
+    {% endblock %}
   </div>
+  <nav class="navbar navbar-expand-lg navbar-light bg-light justify-content-end">
+  <ul class="nav">
+    <li class="nav-item">
+      <a class="nav-link active" href="https://github.com/leanprover-community/leanprover-community.github.io/blob/newsite/templates/{{ name }}">Edit this page on GitHub</a>
+    </li>
+  </ul>
+</nav>
     <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
     <script src="{{ base_url }}/js/bootstrap.min.js"></script>
     {% block extrajs %}{% endblock %}

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -26,6 +26,7 @@
     <title>Lean community</title>
   </head>
   <body>
+  <div id="wrapper">
   <nav class="navbar navbar-expand-lg navbar-light bg-gradient-light">
     <div class="d-flex flex-grow-1">
 		<a class="navbar-brand" href="{{ base_url }}index.html">Lean Community
@@ -60,13 +61,16 @@
 	  {% block content %}
     {% endblock %}
   </div>
-  <nav class="navbar navbar-expand-lg navbar-light bg-light justify-content-end">
+</div>
+{% if name is defined %}
+  <nav class="footer navbar navbar-expand-lg navbar-light bg-light justify-content-end">
   <ul class="nav">
     <li class="nav-item">
       <a class="nav-link active" href="https://github.com/leanprover-community/leanprover-community.github.io/blob/newsite/templates/{{ name }}">Suggest edits to this page on GitHub</a>
     </li>
   </ul>
 </nav>
+{% endif %}
     <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
     <script src="{{ base_url }}/js/bootstrap.min.js"></script>
     {% block extrajs %}{% endblock %}

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -63,7 +63,7 @@
   <nav class="navbar navbar-expand-lg navbar-light bg-light justify-content-end">
   <ul class="nav">
     <li class="nav-item">
-      <a class="nav-link active" href="https://github.com/leanprover-community/leanprover-community.github.io/blob/newsite/templates/{{ name }}">Edit this page on GitHub</a>
+      <a class="nav-link active" href="https://github.com/leanprover-community/leanprover-community.github.io/blob/newsite/templates/{{ name }}">Suggest edits to this page on GitHub</a>
     </li>
   </ul>
 </nav>


### PR DESCRIPTION
This adds a navbar to the bottom of all pages generated from markdown with "Edit this page on GitHub" in the bottom right:

<img width="693" alt="Screenshot 2020-05-14 23 25 57" src="https://user-images.githubusercontent.com/5209952/82008411-9e84e300-963a-11ea-88d1-1c2e3e68a158.png">

cf. https://github.com/leanprover-community/mathlib/pull/2676#issuecomment-628487986 by @robertylewis 