### PR TITLE
host mathlib paper on our own site

### DIFF
--- a/make_site.py
+++ b/make_site.py
@@ -239,7 +239,7 @@ def render_site(target: Path, base_url: str, reloader=False):
             filters={ 'url': url, 'md': render_markdown, 'tex': clean_tex },
             mergecontexts=True)
 
-    for folder in ['css', 'js', 'img']:
+    for folder in ['css', 'js', 'img', 'papers']:
         subprocess.call(['rsync', '-a', folder, str(target).rstrip('/')])
     site.render(use_reloader=reloader)
 


### PR DESCRIPTION
I don't really care which version we link to, but there are existing links out there to leanprover-community.github.io/papers/mathlib-paper.pdf, so let's keep a copy there to be safe.

@PatrickMassot tagging you to make sure this is the only necessary change. The paper file is already there.