### PR TITLE
Overview: generate the overview.html

### DIFF
--- a/data/overview.yaml
+++ b/data/overview.yaml
@@ -1,4 +1,4 @@
-1.
+# 1.
 Linear algebra:
   vector space: 'algebra/module.html#vector_space'
   linear map: 'algebra/module.html#linear_map'
@@ -67,8 +67,7 @@ Linear algebra:
   Dunford decomposition: ''
   endomorphism exponential: ''
   matrix exponential: ''
-
-2.
+# 2.
 Groups:
   basic definitions:
     group: 'core/init/algebra/group.html#group'
@@ -114,8 +113,7 @@ Groups:
     characters of a finite dimensional representation: ''
     orthonormal basis of irreducible characters: ''
     examples for groups with a small cardinal: ''
-
-3.
+# 3.
 Rings:
   ring:
   Unitary ring:
@@ -185,7 +183,7 @@ Fields:
     R(X)-partial fraction decomposition:
     C(X)-partial fraction decomposition:
 
-4.
+# 4.
 Bilinear and quadratic forms over a vector space:
   Bilinear:
     bilinear forms:
@@ -232,8 +230,7 @@ Bilinear and quadratic forms over a vector space:
     Euclidean vector spaces of dimension 3:
     Classification of O(2, R):
     Classification of O(3, R):
-
-5.
+# 5.
 Affine and Euclidian Geoemtry (finite dimensional only):
 Affine spaces and associated vector spaces:
   Affine functions and linear associated functions:
@@ -266,8 +263,7 @@ Affine spaces and associated vector spaces:
     foyer:
     eccentricity:
     quadratics on 3 dimensional euclidean affine spaces:
-
-6.
+# 6.
 Single Variable Real Analysis:
   Real Numbers:
     R as a field:
@@ -351,8 +347,7 @@ Single Variable Real Analysis:
     Continuity and differentiability of the convex functions:
     Characterizations of convexity:
     Convexity inequalities:
-
-7.
+# 7.
 Single Variable Complex Analysis:
   Complex Valued series:
     Radius of convergence:
@@ -384,8 +379,7 @@ Single Variable Complex Analysis:
     Residue theorem:
     Sequences and series of holomorphic functions:
     Holomorphic stability by uniform convergence:
-
-8.
+# 8.
 Topology:
   Topology and Metric Spaces:
     Topology of a metric space:
@@ -433,7 +427,7 @@ Topology:
     Lax-Milgram theorem:
     H10(|0,1|) and its application to the Dirichlet problem in one dimension:
 
-9.
+# 9.
 Differential Calculus:
   Differential Calculus:
     Differentiable functions on an open subset of R^n:
@@ -489,8 +483,7 @@ Differential Calculus:
     curve length:
       C^1 case:
     Lagrange multipliers:
-
-10.
+# 10.
 Integral Calculus:
   measure theory:
     measurable spaces:
@@ -534,8 +527,7 @@ Fourier Analysis:
   Parseval theorem:
   Fourier transforms on L^1(R^d) and L^2(R^d):
   Plancherel’s theorem:
-
-11.
+# 11.
 Probability Theory:
 Definitions of a probabilistic space:
   Events:
@@ -579,8 +571,7 @@ Convergence of series of random variables:
     Strong form:
     Weak form:
   central limit theorem:
-
-12.
+# 12.
 Distribution calculus:
   integration by parts:
   Distributions on Rd:
@@ -627,9 +618,7 @@ Applications:
   solving the laplace equations:
   heat equations:
   wave equations:
-
-
-13.
+# 13.
 Numerical Analysis:
 Solving systems of linear inequalities:
   conditioning:

--- a/make_site.py
+++ b/make_site.py
@@ -136,18 +136,24 @@ class Overview:
     depth: int
     title: str
     decl: Optional[str] = None
+    parent: Optional['Overview'] = None
     children: List['Overview'] = field(default_factory=list)
 
     @classmethod
-    def from_node(cls, identifier: str, title: str, children, depth: int) -> 'Overview':
-        return cls(
+    def from_node(cls, identifier: str, title: str, children, depth: int, parent: 'Overview' = None) -> 'Overview':
+        node = cls(
                 id=identifier,
                 depth=depth,
                 title=title,
                 decl=children if not isinstance(children, dict) else None,
-                children=[cls.from_node(f"{identifier}-{index}", title, subchildren, depth + 1) for index, (title, subchildren) in enumerate(children.items())]
-                if isinstance(children, dict) else []
-        )
+                parent=parent,
+                children=[])
+
+        if isinstance(children, dict):
+            node.children = [cls.from_node(f"{identifier}-{index}", title, subchildren, depth + 1, parent=node) for index, (title, subchildren) in enumerate(children.items())]
+
+        return node
+
 
     @classmethod
     def from_top_level(cls, index: int, title: str, children) -> 'Overview':

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -1,27 +1,40 @@
 {% extends '_base.html' %}
 {% block content %}
 
-  <div class="row mt-3">
-    <div class="col">
-        <h1>Overview of multiple mathematical statements in mathlib</h1>
-        
-        <p>This page tracks usual mathematical theories that are or not are in mathlib currently.</p>
+<div class="row mt-3">
+        <div class="col">
+                <h1>Overview of multiple mathematical statements in mathlib</h1>
 
-  <div class="list-group">
-    {% for statement in overviews recursive %}
-       <div class="list-group-item">
-          <h5 class="card-title markdown-heading" id="{{ statement.id }}">{{ statement.title }}
-                <a class="hover-link" href="#{{ statement.id }}">#</a></h5> 
-          {% if not statement.children and not statement.decl %}
-          <h6 class="card-title">This is currently not in mathlib! You can help us to fix this!</h6>
-          {% elif not statement.children %}
-          <h6 class="card-title"><a href="/mathlib_docs/{{ statement.decl }}">See it in mathlib documentation</a></h6>
-          {% endif %}
-          {% if statement.children %}
-                  {{ loop(statement.children) }}
-          {% endif %}
-       </div>
-    {% endfor %}
-  </div>
+                <p>This page tracks usual mathematical theories that are or not are in mathlib currently.</p>
 
+                <div id="overview-accordion">
+                        {% for statement in overviews recursive %}
+                        <div class="card">
+                                <div class="card-header" id="heading-{{statement.id}}">
+                                        <h5 class="card-title markdown-heading" id="{{ statement.id }}">
+                                                <a role="button" data-toggle="collapse" href="#collapse-{{statement.id}}" aria-expanded="true" aria-controls="collapse-{{statement.id}}">
+                                                        {{ statement.title }}
+                                                </a>
+                                                <a class="hover-link" href="#{{ statement.id }}">#</a>
+                                        </h5>
+                                        <div id="collapse-{{statement.id}}" class="collapse show" data-parent="{% if statement.parent %}#overview-accordion-{{statement.parent.id}} {% else %}#overview-accordion{% endif %}">
+                                                <div class="card-body">
+                                                        <div id="overview-accordion-{{statement.id}}">
+                                                                {% if not statement.children and not statement.decl %}
+                                                                <h6 class="card-title">This is currently not in mathlib! You can help us to fix this!</h6>
+                                                                {% elif not statement.children %}
+                                                                <h6 class="card-title"><a href="/mathlib_docs/{{ statement.decl }}">See it in mathlib documentation</a></h6>
+                                                                {% endif %}
+                                                                {% if statement.children %}
+                                                                {{ loop(statement.children) }}
+                                                                {% endif %}
+                                                        </div>
+                                                </div>
+                                        </div>
+                                </div>
+                        </div>
+                        {% endfor %}
+                </div>
+        </div>
+</div>
 {% endblock %}

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -1,0 +1,27 @@
+{% extends '_base.html' %}
+{% block content %}
+
+  <div class="row mt-3">
+    <div class="col">
+        <h1>Overview of multiple mathematical statements in mathlib</h1>
+        
+        <p>This page tracks usual mathematical theories that are or not are in mathlib currently.</p>
+
+  <div class="list-group">
+    {% for statement in overviews recursive %}
+       <div class="list-group-item">
+          <h5 class="card-title markdown-heading" id="{{ statement.id }}">{{ statement.title }}
+                <a class="hover-link" href="#{{ statement.id }}">#</a></h5> 
+          {% if not statement.children and not statement.decl %}
+          <h6 class="card-title">This is currently not in mathlib! You can help us to fix this!</h6>
+          {% elif not statement.children %}
+          <h6 class="card-title"><a href="/mathlib_docs/{{ statement.decl }}">See it in mathlib documentation</a></h6>
+          {% endif %}
+          {% if statement.children %}
+                  {{ loop(statement.children) }}
+          {% endif %}
+       </div>
+    {% endfor %}
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
Here we go, it will generate the overview page using the data in a recursive fashion, presented in a recursion fashion with very basic CSS because I have no styling sense!

It will just build a bunch of Overview objects which can be interpreted as a Nary tree for any N, leafs being nodes which does not have children.

Note I had to edit the overview, because it was not YAML-compliant, I'm relying on the implicit order, that might be suboptimal or not "perfect".

The HTML just follow the same reasoning, it looks already "quite" good.
Here's full page-wide screenshots.

I'll add https://getbootstrap.com/docs/4.4/components/collapse/#accordion-example in some seconds.

Please give me lots of feedback. :)

![screencapture-localhost-8000-overview-html-2020-05-30-01_11_47-2](https://user-images.githubusercontent.com/314564/83312452-9fa93900-a212-11ea-9ecc-410084ca47bb.png)
![screencapture-localhost-8000-overview-html-2020-05-30-01_11_47](https://user-images.githubusercontent.com/314564/83312453-a0da6600-a212-11ea-8c96-68e82ab1884c.png)
