### PR TITLE
List triangle inequality as done in 100.yaml.

### DIFF
--- a/data/100.yaml
+++ b/data/100.yaml
@@ -285,6 +285,8 @@
   title  : Stirling’s Formula
 91:
   title  : The Triangle Inequality
+  decl   : analysis/normed_space/real_inner_product.html#inner_product_space_is_normed_group
+  author : Zhouhang Zhou
 92:
   title  : Pick’s Theorem
 93:


### PR DESCRIPTION
There are many different ways this entry on the list could be
interpreted, but if we take a geometric interpretation then, given
that we now have Euclidean space, defined in such a way as to be a
metric space by definition, `inner_product_space_is_normed_group`
looks like it's the best choice for something that actually proves the
triangle inequality in a nontrivial context.