### PR TITLE
ci: build all branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,9 @@ name: deploy site
 
 on:
   push:
-    branches:
-      - newsite
+    branches-ignore:
+      - 'master'
+      - 'oldsite'
 
 jobs:
   build:
@@ -23,10 +24,12 @@ jobs:
       - name: install Python dependencies
         run: python -m pip install --upgrade pip staticjinja PyYaml mistletoe pybtex pylatexenc
 
-      - if: github.repository == 'leanprover-community/leanprover-community.github.io' && github.ref == 'refs/heads/newsite'
+      - name: build and deploy
         run:
           ./deploy.sh
         env:
           git_hash: ${{ github.sha }}
           DEPLOY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPLOY_GITHUB_USER: leanprover-community-bot
+          github_repo: ${{ github.repository }}
+          github_ref: ${{github.ref  }}

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,9 +5,11 @@ git clone --branch master "https://$DEPLOY_GITHUB_USER:$DEPLOY_GITHUB_TOKEN@gith
 
 ./make_site.py
 
-cd build/
-git config user.email "leanprover.community@gmail.com"
-git config user.name "leanprover-community-bot"
-git add -A .
-git diff-index HEAD
-git diff-index --quiet HEAD || { git commit -m "deploy site from $git_hash" && git push; }
+if [ "$github_repo" = "leanprover-community/leanprover-community.github.io" -a "$github_ref" = "refs/heads/newsite" ]; then
+  cd build/
+  git config user.email "leanprover.community@gmail.com"
+  git config user.name "leanprover-community-bot"
+  git add -A .
+  git diff-index HEAD
+  git diff-index --quiet HEAD || { git commit -m "deploy site from $git_hash" && git push; }
+fi


### PR DESCRIPTION
This changes the GitHub actions and scripts so that all branches except for `master` and `oldsite` are built with CI. The deploy to `master` only occurs for the `newsite` branch.