### PR TITLE
overview: Section 6

### DIFF
--- a/data/overview.yaml
+++ b/data/overview.yaml
@@ -270,62 +270,66 @@ Affine spaces and associated vector spaces:
 # 6.
 Single Variable Real Analysis:
   Real Numbers:
-    $\R$ as a field: 'data/real/basic.html#real.division_ring'
-    Topology of R: 
-    Additive subgroups of $\R$:
-    Series of real numbers:
-      convergence:
-      limit point:
-      recurrent sequences:
-      Limit infimum and supremum:
-    Completeness of R: 'data/real/cau_seq_completion.html#cau_seq.complete'
+    definition of $\R$: 'data/real/basic.html#real'
+    field structure: 'data/real/basic.html#real.division_ring'
+    order: 'data/real/basic.html#real.linear_order'
+  Sequences of real numbers:
+    convergence: 'order/filter/basic.html#filter.tendsto'
+    limit point: 
+    recurrent sequences: 'core/init/core.html#nat'
+    Limit infimum and supremum: 'order/liminf_limsup.html'
+    Cauchy sequences: 'topology/uniform_space/cauchy.html#cauchy_seq'
+  Topology of R: 
+    metric structure: 'topology/metric_space/basic.html#real.metric_space'
+    Completeness of R: 'topology/instances/real.html#real.complete_space'
     Bolzano-Weierstrass theorem:
-    Compact subsets of $\R$:
-    Cauchy series:
-    Connected subsets of $\R$:
+    Compact subsets of $\R$: 'topology/metric_space/basic.html#metric.compact_iff_closed_bounded'
+    Connected subsets of $\R$: 
+    Additive subgroups of $\R$:
   Numerical Series:
-    Convergence of real valued-series:
-    Geometric series:
+    Convergence of real valued-series: 
+    Geometric series: 'analysis/specific_limits.html#has_sum_geometric_of_abs_lt_1'
     Riemann series:
     Positive valued series:
     Summation of comparison relations:
     Comparison of a series and an integral:
     Error estimation:
-    Absolute convergence:
+    Absolute convergence: 
     Products of series:
     Alternating series:
   Real-valued functions defined on a subset of $\R$:
-    Continuity: 'topology/instances/real.html#real.continuous_abs'
-    Limits:
-    Intermediate value theorem:
+    Continuity: 'topology/basic.html#continuous'
+    Limits: 'order/filter/basic.html#filter.tendsto'
+    Intermediate value theorem: 'topology/algebra/ordered.html#intermediate_value_Icc'
     Image of a segment:
     Continuity of monotonic functions:
     Continuity of reciprocal functions:
-    Differentiability:
-      Derivative at a point:
-      Differentiable functions:
-      Derivative of a composite function:
-      Derivative of a reciprocal function:
-      Rolle's theorem:
-      Mean value theorem:
-      Derivatives of higher order functions:
-      Applications to C-k class:
-        C-k class:
-        piecewise C-k class:
-      Leibniz formula:
-      Taylor-like theorems:
-        Taylor with rough error estimation:
-        Taylor with integral error estimation:
-        Taylor-Lagrange:
-      Series expansions:
-  \"Usual\" functions (trig, rational, $\exp$, $\log$, etc):
-    Polynomial functions:
+  Differentiability:
+    Derivative at a point: 'analysis/calculus/deriv.html#has_deriv_at'
+    Differentiable functions: 'analysis/calculus/deriv.html#has_deriv_at'
+    Derivative of a composite function: 'analysis/calculus/deriv.html#deriv.comp'
+    Derivative of a reciprocal function: 'analysis/calculus/deriv.html#has_strict_deriv_at.of_local_left_inverse'
+    Rolle's theorem: 'analysis/calculus/local_extr.html#exists_deriv_eq_zero'
+    Mean value theorem: 'analysis/calculus/mean_value.html#exists_ratio_deriv_eq_ratio_slope'
+    Higher order derivatives of functions: 'analysis/calculus/iterated_deriv.html#iterated_deriv'
+    $C^k$ functions: 'analysis/calculus/times_cont_diff.html#times_cont_diff'
+    piecewise $C^k$ functions:
+    Leibniz formula: 'analysis/calculus/deriv.html#deriv_mul'
+  Taylor-like theorems:
+    Taylor with rough error estimation:
+    Taylor with integral error estimation:
+    Taylor-Lagrange:
+    Series expansions:
+  Usual functions (trigonometric, rational, $\exp$, $\log$, etc):
+    Polynomial functions: 'data/polynomial.html#polynomial.eval'
     Rational functions:
-    Logarithms:
-    Exponential:
-    Power functions:
-    Circular and hyperbolic functions:
-    Reciprocal circular and hyperbolic functions:
+    Logarithms: 'analysis/special_functions/exp_log.html#real.log'
+    Exponential: 'data/complex/exponential.html#real.exp'
+    Power functions: 'algebra/group_power.html#monoid.pow'
+    Circular trigonometric functions: 'data/complex/exponential.html#real.sin'
+    Hyperbolic trigonometric functions: 'data/complex/exponential.html#real.sinh'
+    Reciprocal circular trigonometric functions: 'analysis/special_functions/trigonometric.html#real.arcsin'
+    Reciprocal hyperbolic trigonometric functions: 
   Integration:
     Integral over a segment of piecewise continuous functions:
     Antiderivatives:
@@ -340,17 +344,17 @@ Single Variable Real Analysis:
     Semi-convergent integrals:
   Sequences and series of functions:
     Pointwise convergence:
-    Uniform convergence:
+    Uniform convergence: 'topology/uniform_space/uniform_convergence.html#tendsto_uniformly'
     Normal convergence:
-    Continuity and differentiability of the limit:
-    Weierstrass approximation theorem:
-      Polynomial version:
-      Trigonometric version:
+    Continuity of the limit: 'topology/uniform_space/uniform_convergence.html#continuous_of_uniform_approx_of_continuous'
+    Differentiability of the limit: 
+    Weierstrass polynomial approximation theorem:
+    Weierstrass trigonometric approximation theorem:
   Convexity:
-    Convex functions of a real variable:
-    Continuity and differentiability of the convex functions:
-    Characterizations of convexity:
-    Convexity inequalities:
+    Convex functions of a real variable: 'analysis/convex/basic.html#convex_on'
+    Continuity and differentiability of convex functions:
+    Characterizations of convexity: 'analysis/calculus/mean_value.html#convex_on_of_deriv2_nonneg'
+    Convexity inequalities: 'analysis/mean_inequalities.html'
 # 7.
 Single Variable Complex Analysis:
   Complex Valued series:


### PR DESCRIPTION
I went through Section 6. It also displays what I think we should do. In particular:
* I moved stuff around a bit, to improve consistency
* I split a couple of items
* when an item has several targets but finding one tells you about the other, I didn't split, and indicated where to find one target. For instance, "Circular trigonometric function" links to the definition of sin. I did split circular and hyperbolic, especially since we don't have reciprocals hyperbolic trig functions
* When we can obviously express something but the definitions is not there, I didn't write anything. I think we should add those definitions to mathlib, in particular for the sake of discoverability. For instance we don't have convergent series of real numbers.

What I think I have a hard time to do is being consistent about the following question: what do we do when we have a very general form of something, but we would need an API for the elementary version? For instance I resisted the temptation to write that we have Taylor series. We have them in several variables. But since we have the `deriv` vs `fderiv` distinction, I say we don't have Taylor series in one variable.