### PR TITLE
overview.yaml: new links and some re-translations

### DIFF
--- a/data/overview.yaml
+++ b/data/overview.yaml
@@ -39,7 +39,7 @@ Linear algebra:
     special linear group: ''
     orientation of a $\R$-valued vector space: ''
   Matrices:
-    commutative ring valued matrices: 'data/matrix/basic.html#matrix'
+    commutative-ring-valued matrices: 'data/matrix/basic.html#matrix'
     field-valued matrices: 'data/matrix/basic.html#matrix'
     matrix representation of a linear map: 'linear_algebra/matrix.html#linear_map.to_matrix'
     change of basis: ''
@@ -48,7 +48,7 @@ Linear algebra:
     invertibility: 'linear_algebra/nonsingular_inverse.html#matrix.nonsing_inv'
     elementary row operations: ''
     elementary column operations: ''
-    Gauss' pivot: ''
+    Gaussian elimination: ''
     row-reduced matrices: ''
   Endomorphism polynomials:
     annihilating polynomials: ''
@@ -59,9 +59,9 @@ Linear algebra:
     eigenvalues: ''
     eigenvectors: ''
     diagonalization: ''
-    trigonalization: ''
-    endomorphism invariant subspaces: ''
-    characteristic subspaces: ''
+    triangularization: ''
+    invariant subspaces of an endomorphism: ''
+    generalized eigenspaces: ''
     kernels lemma: ''
     Dunford decomposition: ''
     Jordan normal form: ''
@@ -163,7 +163,7 @@ Ring Theory:
     roots of a polynomial: 'data/polynomial.html#polynomial.roots'
     multiplicity: 'data/polynomial.html#polynomial.root_multiplicity'
     relationship between the coefficients and the roots of a split polynomial:
-    Newton's sums:
+    Newton's identities:
     polynomial derivative: 'data/polynomial.html#polynomial.derivative'
     decomposition into sums of homogeneous polynomials:
     symmetric polynomials:
@@ -206,15 +206,15 @@ Bilinear and Quadratic Forms Over a Vector Space:
   Orthogonality:
     orthogonal elements: 'linear_algebra/bilinear_form.html#bilin_form.is_ortho'
     adjoint endomorphism:
-    inertia law of Sylvester:
+    Sylvester's law of inertia:
     real classification:
     complex classification:
-    Schmidt orthogonalisation:
+    Gram-Schmidt orthogonalisation:
   Euclidean and Hermitian spaces:
     Euclidean vector spaces: 'analysis/normed_space/real_inner_product.html#inner_product_space'
     Hermitian vector spaces:
     dual isomorphism in the euclidean case:
-    orthogonal supplementary:
+    orthogonal complement:
     Cauchy-Schwarz inequality: 'analysis/normed_space/real_inner_product.html#inner_mul_inner_self_le'
     norm: 'analysis/normed_space/real_inner_product.html#inner_product_space_has_norm'
     orthonormal bases:
@@ -223,12 +223,12 @@ Bilinear and Quadratic Forms Over a Vector Space:
     unitary group:
     special orthogonal group:
     special unitary group:
-    symmetrical endomorphism: 'linear_algebra/bilinear_form.html#bilin_form.is_self_adjoint'
+    self-adjoint endomorphism: 'linear_algebra/bilinear_form.html#bilin_form.is_self_adjoint'
     normal endomorphism:
-    diagonalization of a symmetrical endomorphism:
+    diagonalization of a self-adjoint endomorphism:
     diagonalization of normal endomorphisms:
-    simultaneous reduction of two real quadratic forms with a definite positive one:
-    decomposition of an orthogonal automorphism in product of reflections:
+    simultaneous diagonalization of two real quadratic forms, with one positive-definite:
+    decomposition of an orthogonal transformation as a product of reflections:
     polar decompositions in $\mathrm{GL}(n, \R)$:
     polar decompositions in $\mathrm{GL}(n, \C)$:
   Low dimensions:
@@ -323,10 +323,10 @@ Single Variable Real Analysis:
     piecewise $C^k$ functions:
     Leibniz formula: 'analysis/calculus/deriv.html#deriv_mul'
   Taylor-like theorems:
-    Taylor with rough error estimation:
-    Taylor with integral error estimation:
-    Taylor-Lagrange:
-    series expansions:
+    Taylor's theorem with Peano form for remainder:
+    Taylor's theorem with integral form for remainder:
+    Taylor's theorem with Lagrange form for remainder:
+    Taylor series expansions:
   Usual functions (trigonometric, rational, $\exp$, $\log$, etc):
     polynomial functions: 'data/polynomial.html#polynomial.eval'
     rational functions:
@@ -415,51 +415,52 @@ Topology:
     uniformly continuous functions: 'topology/metric_space/basic.html#metric.uniform_continuous_iff'
     Heine-Cantor theorem:
     complete metric spaces: 'topology/metric_space/basic.html#metric.complete_of_cauchy_seq_tendsto'
-    fixed point theorem for contraction mapping: 'topology/metric_space/contracting.html#contracting_with.exists_fixed_point'
+    contraction mapping theorem: 'topology/metric_space/contracting.html#contracting_with.exists_fixed_point'
   Normed vector spaces on $\R$ and $\C$:
     topology on a normed vector space: 'analysis/normed_space/basic.html#normed_space.topological_vector_space'
     equivalent norms:
-    continuity of linear maps in finite dimension: 'normed_space/finite_dimension.html#linear_map.continuous_of_finite_dimensional'
-    normes $\lVert\cdot\rVert_p$ on $\R^n$ and $\C^n$:
-    continuous linear functions: 'topology/algebra/module.html#continuous_linear_map'
-    norm of a continuous linear function: 'analysis/normed_space/operator_norm.html#linear_map.mk_continuous'
-    absolutely convergent series on Banach spaces: 'analysis/normed_space/basic.html#summable_of_summable_norm'
-    Banach open mapping theorem:  'analysis/normed_space/banach.html#open_mapping'
+    Banach open mapping theorem: 'analysis/normed_space/banach.html#open_mapping'
+    equivalence of norms in finite dimension: 'normed_space/finite_dimension.html#linear_equiv.to_continuous_linear_equiv'
+    norms $\lVert\cdot\rVert_p$ on $\R^n$ and $\C^n$: 'topology/metric_space/pi_Lp.html#pi_Lp.normed_space'
+    absolutely convergent series in Banach spaces: 'analysis/normed_space/basic.html#summable_of_summable_norm'
+    continuous linear maps: 'topology/algebra/module.html#continuous_linear_map'
+    norm of a continuous linear map: 'analysis/normed_space/operator_norm.html#linear_map.mk_continuous'
     uniform convergence norm (sup-norm): 'topology/metric_space/emetric_space.html#emetric.tendsto_uniformly_on_iff'
-    complete space of continuous bounded complete space valued functions: 'topology/bounded_continuous_function.html#bounded_continuous_function.complete_space'
-    closed and bounded subsets are compact in finite-dimension: 'analysis/normed_space/finite_dimension.html#finite_dimensional.proper'
-    Riesz' characterization of finite dimension:
-    Ascoli's Theorem: 'topology/bounded_continuous_function.html#bounded_continuous_function.arzela_ascoli'
+    normed space of bounded continuous normed-space-valued functions: 'topology/bounded_continuous_function.html#bounded_continuous_function.normed_space'
+    its completeness: 'topology/bounded_continuous_function.html#bounded_continuous_function.complete_space'
+    Heine-Borel theorem (closed bounded subsets are compact in finite dimension): 'analysis/normed_space/finite_dimension.html#finite_dimensional.proper'
+    Riesz' lemma (unit-ball characterization of finite dimension):
+    Arzela-Ascoli theorem: 'topology/bounded_continuous_function.html#bounded_continuous_function.arzela_ascoli'
   Hilbert Spaces:
     Hilbert projection theorem:
     orthogonal projection onto closed vector subspaces:
-    dual space:
+    dual space: 'analysis/normed_space/dual.html#normed_space.dual.inst'
     Riesz representation theorem:
     $l^2$ and $L^2$ cases:
-    Hilbert bases (in the separable case):
-    basis of trigonometric polynomials:
-    basis of orthogonal polynomials:
+    Hilbert (orthonormal) bases (in the separable case):
+    Hilbert basis of trigonometric polynomials:
+    Hilbert bases of orthogonal polynomials:
     Lax-Milgram theorem:
-    $H^1_0([0,1])$ and its application to the Dirichlet problem in one dimension:
+    $H^1_0([0,1])$ and its application to the one-dimensional Dirichlet problem:
 
 # 9.
 Multivariable calculus:
   Differential Calculus:
     differentiable functions on an open subset of $\R^n$: 'analysis/calculus/fderiv.html#differentiable_on'
     differentials (linear tangent functions): 'analysis/calculus/fderiv.html#fderiv'
-    derivatives with respect to a vector:
+    directional derivative:
     partial derivatives:
-    jacobian matrix:
+    Jacobian matrix:
     gradient vector:
     Hessian matrix:
     chain rule: 'analysis/calculus/fderiv.html#fderiv.comp'
     mean value theorem: 'analysis/calculus/mean_value.html#exists_ratio_deriv_eq_ratio_slope'
     differentiable functions: 'analysis/calculus/fderiv.html#differentiable'
-    functions that can be continuously differentiated $k$ times: 'analysis/calculus/times_cont_diff.html#times_cont_diff'
-    partial derivatives:
-    commutativity of partial derivatives:
-    Taylor theorem with rough error estimation:
-    Taylor theorem with integral error estimation:
+    $k$-times continuously differentiable functions: 'analysis/calculus/times_cont_diff.html#times_cont_diff'
+    $k$-th order partial derivatives:
+    partial derivatives commute:
+    Taylor's theorem with Peano form for remainder:
+    Taylor's theorem with integral form for remainder:
     local extrema: 'analysis/calculus/local_extr.html#is_local_min.fderiv_eq_zero'
     convexity of functions on an open convex subset of $\R^n$: 'analysis/convex/basic.html#convex_on'
     diffeomorphisms: 'geometry/manifold/manifold.html#structomorph'

--- a/data/overview.yaml
+++ b/data/overview.yaml
@@ -323,7 +323,7 @@ Single Variable Real Analysis:
     piecewise $C^k$ functions:
     Leibniz formula: 'analysis/calculus/deriv.html#deriv_mul'
   Taylor-like theorems:
-    Taylor's theorem with Peano form for remainder:
+    Taylor's theorem with little-o remainder:
     Taylor's theorem with integral form for remainder:
     Taylor's theorem with Lagrange form for remainder:
     Taylor series expansions:
@@ -459,7 +459,7 @@ Multivariable calculus:
     $k$-times continuously differentiable functions: 'analysis/calculus/times_cont_diff.html#times_cont_diff'
     $k$-th order partial derivatives:
     partial derivatives commute:
-    Taylor's theorem with Peano form for remainder:
+    Taylor's theorem with little-o remainder:
     Taylor's theorem with integral form for remainder:
     local extrema: 'analysis/calculus/local_extr.html#is_local_min.fderiv_eq_zero'
     convexity of functions on an open convex subset of $\R^n$: 'analysis/convex/basic.html#convex_on'


### PR DESCRIPTION
I added links to some newly-merged analysis facts ([#3059](https://github.com/leanprover-community/mathlib/pull/3059), [#3021](https://github.com/leanprover-community/mathlib/pull/3021), [#2660](https://github.com/leanprover-community/mathlib/pull/2660) ).  I also changed some translations that I found inelegant -- but I know that many of these may have been discussed already, so feel free to revert any.