### PR TITLE
rename "computer science and set theory" in overview

### DIFF
--- a/data/overview.yaml
+++ b/data/overview.yaml
@@ -262,8 +262,8 @@ Analysis:
       tangent map: 'tangent_map'
       
 
-Computer science and set theory:
-  Computer science:
+Logic and computation:
+  Computability:
     computable function: 'computable'
     Turing machine: 'turing.TM0.machine'
     halting problem: 'computable_pred.halting_problem'


### PR DESCRIPTION
"computer science and set theory" doesn't make any sense as a category.