### PR TITLE
add code of conduct

### DIFF
--- a/data/community.md
+++ b/data/community.md
@@ -65,3 +65,44 @@ The largest past events were:
 
 * [FoMM 2020](http://www.andrew.cmu.edu/user/avigad/meetings/fomm2020/)
 * [Lean Together 2019](https://lean-forward.github.io/lean-together/2019/)
+
+## Community guidelines
+
+We are devoted to developing an open and accepting community
+that welcomes participation from everyone.
+Behavior that is offensive, discriminatory, or aggressive
+will not be tolerated in any form.
+We adopt the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).
+These guidelines apply to the 
+[Lean Zulip chat](https://leanprover.zulipchat.com/) 
+and the [leanprover-community GitHub organization](https://github.com/leanprover-community/).
+
+The [maintainer team](#maintainers) enforces this code of conduct.
+Jeremy Avigad, Anne Baanen, and Simon Hudon serve as first points of contact
+for reporting any concerns.
+We also provide an [anonymous form](https://docs.google.com/forms/d/e/1FAIpQLSdEjlFqJQV65F-yzRHl-lyWAt7TSUW1axPiQK3RyV67iu1h6Q/viewform)
+to report incidents that violate the community guidelines.
+
+We encourage a policy of de-escalation in the presence of unwelcome behavior.
+If you perceive someone acting in a way that violates our code of conduct,
+please do not respond in the same way; instead, take action to correct the behavior,
+such as reporting it to the moderators.
+
+## Maintainers
+
+Mathlib maintainers are community members who are actively
+developing mathlib and reviewing pull requests.
+Their number grows naturally when new users become
+frequent contributors.
+
+Maintainers have permission to merge pull requests to mathlib
+and access to GitHub administration settings.
+Otherwise they are community members like everyone else.
+Community decisions are discussed and made in public channels.
+In particular, everyone is encouraged to review pull requests
+and to contribute to the [supporting tools](http://github.com/leanprover-community/)
+for Lean and mathlib.
+
+If you are interested in eventually joining the maintainer team,
+we encourage you to participate as much as possible in the review process.
+Please contact the current maintainers when you feel prepared.

--- a/templates/meet.html
+++ b/templates/meet.html
@@ -10,13 +10,6 @@
 
   <div class="row mt-3">
     <div class="col">
-        <a name="maintainers"></a> 
-        <h2>Mathlib maintainers</h2>
-        
-        Mathlib maintainers are community members who are actively
-		developing mathlib and reviewing pull requests.
-		Their number grows naturally when new users become
-		frequent contributors.
 
   <div class="row mt-3">
         {% for maintainer in maintainers %}


### PR DESCRIPTION
Pending discussion at https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/community.20code.20of.20conduct so please don't merge this yet.

I've also moved the text about the maintainers to the .md file (and expanded it a bit). It's awkward to have the pictures generated in a separate file but I don't see a way around it. This gives us the `#` link on mouseover for the "Maintainers" heading.