### PR TITLE
Mention tactic `extract_goal` in `mwe.md`

### DIFF
--- a/templates/mwe.md
+++ b/templates/mwe.md
@@ -24,7 +24,8 @@ open set
 #check (univ : set X)
 ```
 
-Tip: If you are using [Mathlib](https://github.com/leanprover-community/mathlib) and have `import tactic` in your file, there's a tactic called [extract_goal](https://leanprover-community.github.io/mathlib_docs/tactics.html#extract_goal) that can help you format the current goal as a stand-alone example, you just need to also include the corresponding `import`s and `open`s and `universe`s and `variable`s to create a minimal working examples.
+Tip: If you are using [Mathlib](https://github.com/leanprover-community/mathlib) and have `import tactic` in your file, there's a tactic called [`extract_goal`](https://leanprover-community.github.io/mathlib_docs/tactics.html#extract_goal) that can help you format the current goal as a stand-alone example.
+Note you still need to include the corresponding `import`s and `open`s and `universe`s and `variable`s as mentioned above.
 
 ## Formal Definition
 

--- a/templates/mwe.md
+++ b/templates/mwe.md
@@ -24,6 +24,8 @@ open set
 #check (univ : set X)
 ```
 
+Tip: If you are using [Mathlib](https://github.com/leanprover-community/mathlib) and have `import tactic` in your file, there's a tactic called [extract_goal](https://leanprover-community.github.io/mathlib_docs/tactics.html#extract_goal) that can help you format the current goal as a stand-alone example, you just need to also include the corresponding `import`s and `open`s and `universe`s and `variable`s to create a minimal working examples.
+
 ## Formal Definition
 
 A **minimal working example** is a code snippet that can be copied-and-pasted into an empty Lean file and still have the same features (working) and that does not include unnecessary details (minimal).

--- a/templates/mwe.md
+++ b/templates/mwe.md
@@ -24,7 +24,8 @@ open set
 #check (univ : set X)
 ```
 
-Tip: If you are using [Mathlib](https://github.com/leanprover-community/mathlib) and have `import tactic` in your file, there's a tactic called [`extract_goal`](https://leanprover-community.github.io/mathlib_docs/tactics.html#extract_goal) that can help you format the current goal as a stand-alone example.
+Tip: If you are using [Mathlib](https://github.com/leanprover-community/mathlib) and have `import tactic` in your file, there's a tactic called [`extract_goal`](https://leanprover-community.github.io/mathlib_docs/tactics.html#extract_goal) that can help you format the current goal as a stand-alone example. You can remove extraneous variables and hypotheses from the output of `extract_goal` to further minimize your example.
+
 Note you still need to include the corresponding `import`s and `open`s and `universe`s and `variable`s as mentioned above.
 
 ## Formal Definition


### PR DESCRIPTION
See [Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Being.20stuck.20-.3E.20MWE/near/206124531).

When people are asked to provide a `#mwe` on Zulip, they can directly see the tip about using `extract_goal` to create a `#mwe`.