### PR TITLE
link to projects page

### DIFF
--- a/data/menus.yaml
+++ b/data/menus.yaml
@@ -11,7 +11,7 @@
     - The natural number game: http://wwwf.imperial.ac.uk/~buzzard/xena/natural_number_game/
     - Library overview: mathlib-overview.html
     - API documentation: https://leanprover-community.github.io/mathlib_docs
-- title: Community 
+- title: Community
   open_right: True
   items:
     - Meet us: meet.html
@@ -19,3 +19,4 @@
     - Maintainers: meet.html#maintainers
     - How to contribute: contribute/index.html
     - Papers: papers.html
+    - Projects: lean_projects.html

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,7 +2,7 @@
 {% block content %}
 
   <div class="row justify-content-center mt-4">
-    <div class="col-md-6 text-center">  
+    <div class="col-md-6 text-center">
     <img src="img/community_logo_emb.svg" alt="Lean community"
                 class="img-fluid w-100"/>
     </div>
@@ -18,11 +18,11 @@
         <div class="card-body">
 		  <h4>Try it!</h4>
           <p>
-          You can 
-          try Lean in your web browser, 
-          install it in an isolated folder, 
-          or go for the full install. 
-          Lean is free, open source software. It works on 
+          You can
+          try Lean in your web browser,
+          install it in an isolated folder,
+          or go for the full install.
+          Lean is free, open source software. It works on
           Linux, Windows, and MacOS.
           </p>
 		</div>
@@ -38,7 +38,7 @@
         <div class="card-body">
 		<h4>Learn to Lean!</h4>
 		<p>
-    You can learn by playing a game, following tutorials, 
+    You can learn by playing a game, following tutorials,
     or reading books.
 		</p>
 		</div>
@@ -55,8 +55,8 @@
 		<h4>Meet the community!</h4>
 		<p>
         Lean has very diverse and active community. It gathers mostly on
-    a <a href="https://leanprover.zulipchat.com/">Zulip chat</a> 
-    and on <a href="https://github.com/leanprover-community/mathlib">GitHub</a>. 
+    a <a href="https://leanprover.zulipchat.com/">Zulip chat</a>
+    and on <a href="https://github.com/leanprover-community/mathlib">GitHub</a>.
     You can get involved and join the fun!
 		</p>
 		</div>
@@ -70,7 +70,7 @@
       </div>
     </div>
   </div>
-  
+
   <div class="row mt-5">
     <div class="col">
 		{{ what_is | md }}
@@ -78,7 +78,7 @@
   </div>
 
   <div class="row mt-3">
-    <div class="col"> 
+    <div class="col">
 	  <h2>Formalized with Lean and mathlib</h2>
 	</div>
   </div>
@@ -99,8 +99,9 @@
 	{% endfor %}
   </div>
   <div class="row mt-2 mb-2">
-    <div class="col"> 
-		You can find many more in the <a href="papers.html">list of papers</a>.
+    <div class="col">
+    You can find many more in the <a href="papers.html">list of papers</a>
+    and <a href="lean_projects.html">list of projects</a>.
 	</div>
   </div>
 

--- a/templates/lean_projects.html
+++ b/templates/lean_projects.html
@@ -34,6 +34,11 @@
       please see the directions at the
       <a href="https://github.com/leanprover-contrib/leanprover-contrib">leanprover-contrib</a> page.
     </p>
+
+    <p>
+      This list and the repository that manages it are both works in progress.
+      Please add your own project and report any problems!
+    </p>
     </div>
   </div>
 
@@ -81,7 +86,7 @@
           on all of these <code>lean-x.y.z</code> branches.
         </li>
         <li>
-          A × in the <code>x.y.z</code> column means that the project has an <code>lean-x.y.z</code> branch
+          An × in the <code>x.y.z</code> column means that the project has an <code>lean-x.y.z</code> branch
           but it fails to build.
         </li>
         <li>
@@ -89,6 +94,10 @@
           does not have an <code>x.y.z</code> branch.
         </li>
       </ul>
+      <p>
+        Note that an × does not necessarily mean the project does not compile,
+        just that it does not compile with updated dependencies.
+      </p>
     </div>
 
     <div class="col-12">

--- a/templates/lean_projects.html
+++ b/templates/lean_projects.html
@@ -32,12 +32,12 @@
     <p>
       To add a project to this list,
       please see the directions at the
-      <a href="https://github.com/leanprover-contrib/leanprover-contrib">leanprover-contrib</a> page.
+      <a href="https://github.com/leanprover-contrib/leanprover-contrib">leanprover-contrib</a> repository.
     </p>
 
     <p>
       This list and the repository that manages it are both works in progress.
-      Please add your own project and report any problems!
+      Please add your own project and report any problems in that repository.
     </p>
     </div>
   </div>


### PR DESCRIPTION
This is stable enough to link to now, I think. At some point I'm going to move the infrastructure from the `leanprover-contrib` repo to `leanprover-community` but that shouldn't affect the display much.