### PR TITLE
Expand two entries in `lean.bib`

### DIFF
--- a/lean.bib
+++ b/lean.bib
@@ -32,14 +32,25 @@
   website	= {https://github.com/avigad/qpf}
 }
 
-@Article{	  Baanen20,
-  author	= {Anne Baanen},
-  title		= {A Lean tactic for normalising ring expressions with
-		  exponents},
-  url		= {https://lean-forward.github.io/ring_exp/paper.pdf},
-  note		= {IJCAR 2020},
-  year		= {2020},
-  tags		= {about-mathlib, lean3}
+@InProceedings{	  Baanen20,
+  author    = {Anne Baanen},
+  editor    = {Nicolas Peltier and
+               Viorica Sofronie{-}Stokkermans},
+  title     = {A Lean Tactic for Normalising Ring Expressions with Exponents (Short
+               Paper)},
+  booktitle = {Automated Reasoning - 10th International Joint Conference, {IJCAR}
+               2020, Paris, France, July 1-4, 2020, Proceedings, Part {II}},
+  series    = {Lecture Notes in Computer Science},
+  volume    = {12167},
+  pages     = {21--27},
+  publisher = {Springer},
+  year      = {2020},
+  url       = {https://doi.org/10.1007/978-3-030-51054-1\_2},
+  doi       = {10.1007/978-3-030-51054-1\_2},
+  timestamp = {Thu, 06 Aug 2020 21:49:45 +0200},
+  biburl    = {https://dblp.org/rec/conf/cade/Baanen20.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org},
+  tags      = {about-mathlib, lean3}
 }
 
 @InProceedings{	  Buch18,
@@ -440,12 +451,20 @@
 }
 
 @Misc{		  SelsamUllrichDeMoura20,
-  author	= {Daniel Selsam and Sebastian Ullrich and Leonardo {de
-		  Moura}},
-  title		= {Tabled Typeclass Resolution},
-  year		= {2020},
-  eprint	= {arXiv:2001.04301},
-  tags		= {about-lean, lean4}
+  author    = {Daniel Selsam and
+               Sebastian Ullrich and
+               Leonardo de Moura},
+  title     = {Tabled Typeclass Resolution},
+  journal   = {CoRR},
+  volume    = {abs/2001.04301},
+  year      = {2020},
+  url       = {https://arxiv.org/abs/2001.04301},
+  archivePrefix = {arXiv},
+  eprint    = {2001.04301},
+  timestamp = {Fri, 17 Jan 2020 14:07:30 +0100},
+  biburl    = {https://dblp.org/rec/journals/corr/abs-2001-04301.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org},
+  tags      = {about-lean, lean4}
 }
 
 @Misc{		  StricklandBellumat19,


### PR DESCRIPTION
I saw that my `ring_exp` paper only had a short description in `lean.bib`, so I added information from dblp to the two entries that could be expanded.