### PR TITLE
Added suggestion to uninstall Windows Store version of Python

### DIFF
--- a/templates/install/windows.md
+++ b/templates/install/windows.md
@@ -36,6 +36,7 @@ In order to use mathlib supporting tools, you need to [get python](https://www.p
 
 ### Get Python
 
+* If you have the Windows Store version of Python, please uninstall it first.
 * Download the latest version of python [here](https://www.python.org/downloads/).
 * Run the downloaded file (`python-3.x.x.exe`)
 * Check `Add Python 3.x to PATH`.


### PR DESCRIPTION
The Windows Store installation of Python seems to cause issues with installing `leanproject`. I think even with the `cp` line there the default for `python3` is still the store version of Python, and running `python3 -m pip` gives an error message saying `Permission Denied`