### PR TITLE
add robots.txt

### DIFF
--- a/make_site.py
+++ b/make_site.py
@@ -425,6 +425,7 @@ def render_site(target: Path, base_url: str, reloader=False):
     for folder in ['css', 'js', 'img', 'papers']:
         subprocess.call(['rsync', '-a', folder, str(target).rstrip('/')])
     subprocess.call(['rsync', '-a', 'googlef0c00cb4d31b246f.html', str(target).rstrip('/')])
+    subprocess.call(['rsync', '-a', 'robots.txt', str(target).rstrip('/')])
 
     site.render(use_reloader=reloader)
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /mathlib_docs_demo/


### PR DESCRIPTION
This tells search engines not to index the demo `doc-gen` builds (see e.g. https://github.com/leanprover-community/doc-gen/pull/110)