### PR TITLE
style(meet): Use bootstrap media rather than cards

### DIFF
--- a/templates/meet.html
+++ b/templates/meet.html
@@ -4,7 +4,7 @@
 
         {{ community | md }}
 
-  <div class="row mt-3">
+  <div class="row mt-5">
         {% for maintainer in maintainers %}
 		<div class="col-md-6">
 			<div class="media mb-3">

--- a/templates/meet.html
+++ b/templates/meet.html
@@ -7,20 +7,12 @@
   <div class="row mt-3">
         {% for maintainer in maintainers %}
 		<div class="col-md-6">
-			<div class="card mb-3">
-			  <div class="row no-gutters">
-				<div class="col-md-3 d-flex align-items-center justify-content-center">
-				  <img src="img/{{ maintainer.img }}" class="p-2"
-													  alt="{{maintainer.name}}
-													  picture">
+			<div class="media mb-3">
+				<img src="img/{{ maintainer.img }}" class="mr-3" alt="{{maintainer.name}} picture">
+				<div class="media-body">
+					<h5 class="mt-0">{{ maintainer.name }}</h5>
+					<p>{{ maintainer.descr }}</p>
 				</div>
-				<div class="col-md-9">
-				  <div class="card-body">
-					<h5 class="card-title">{{ maintainer.name }}</h5>
-					<p class="card-text">{{ maintainer.descr }}</p>
-				  </div>
-				</div>
-			  </div>
 			</div>
 		</div>
         {% endfor %}


### PR DESCRIPTION
This makes the page layout a little denser.

Implemented as described at https://getbootstrap.com/docs/4.6/components/media-object


----

Before / after, showing the change applied to just the top two:

![image](https://user-images.githubusercontent.com/425260/111201048-48663080-85ba-11eb-910b-b03a6be4291e.png)
