### PR TITLE
Normalize titles of pages in theories/

### DIFF
--- a/templates/contribute/naming.md
+++ b/templates/contribute/naming.md
@@ -1,7 +1,8 @@
-# Mathlib naming conventions #
+# Mathlib naming conventions
+
 Author: [Jeremy Avigad](http://www.andrew.cmu.edu/user/avigad)
 
-### Names of symbols ###
+### Names of symbols
 
 When translating the statements of theorems into words, this dictionary is often used:
 
@@ -60,7 +61,7 @@ Lattices:
 | `⨆`    | `\Sup`   | `Sup` |       |
 | `⨅`    | `\Inf`   | `Inf` |       |
 
-### General conventions ###
+### General conventions
 
 Identifiers are generally lower case with underscores. For the most
 part, we rely on descriptive names. Often the name of theorem simply
@@ -113,8 +114,7 @@ We can also use the word "self" to indicate a repeated argument:
 - `mul_inv_self`
 - `neg_add_self`
 
-
-### Dots ###
+### Dots
 
 Dots are used for namespaces, and also for automatically generated names
 like recursors, eliminators and structure projections. They can also be
@@ -169,7 +169,7 @@ inductive types. For instance, we use:
 - `lt.trans_le`
 - `le.trans_lt`
 
-### Axiomatic descriptions ###
+### Axiomatic descriptions
 
 Some theorems are described using axiomatic names, rather than
 describing their conclusions.
@@ -190,8 +190,7 @@ describing their conclusions.
 - `mul_right_cancel`
 - `inj`  (injective)
 
-
-### Variable conventions ###
+### Variable conventions
 
 - `u`, `v`, `w`, ... for universes
 - `α`, `β`, `γ`, ... for generic types
@@ -205,12 +204,12 @@ describing their conclusions.
 - `i`, `j`, `k`, ... for integers
 
 Types with a mathematical content are expressed with the usual
-mathematical notation, often with an upper case letter 
+mathematical notation, often with an upper case letter
 (`G` for a group, `R` for a ring, `K` or `𝕜` for a field, `E` for a vector space, ...).
 This convention is not followed in older files, where greek letters are used
 for all types. Pull requests renaming type variables in these files are welcome.
 
-### Names for symbols ###
+### Names for symbols
 
 - `imp`: implication
 - `forall`
@@ -218,8 +217,7 @@ for all types. Pull requests renaming type variables in these files are welcome.
 - `ball`: bounded forall
 - `bex`: bounded exists
 
-
-## Identifiers and theorem names ##
+## Identifiers and theorem names
 
 We generally use lower case with underscores for theorem names and
 definitions. Sometimes upper case is used for bundled structures, such
@@ -231,6 +229,7 @@ to guess the name of a theorem or find it using tab completion. Common
 "axiomatic" properties of an operation like conjunction or
 disjunction are put in a namespace that begins with the name of the
 operation:
+
 ```lean
 import logic.basic
 
@@ -239,8 +238,10 @@ import logic.basic
 #check and.assoc
 #check or.assoc
 ```
+
 In particular, this includes `intro` and `elim` operations for logical
 connectives, and properties of relations:
+
 ```lean
 import logic.basic
 
@@ -254,7 +255,9 @@ import logic.basic
 #check eq.symm
 #check eq.trans
 ```
+
 Note however we do not do this for axiomatic arithmetic operations
+
 ```lean
 import algebra.group.basic
 
@@ -265,6 +268,7 @@ import algebra.group.basic
 
 For the most part, however, we rely on descriptive names. Often the
 name of theorem simply describes the conclusion:
+
 ```lean
 import algebra.ring.basic
 open nat
@@ -274,14 +278,17 @@ open nat
 #check @sub_add_eq_add_sub
 #check @le_iff_lt_or_eq
 ```
+
 If only a prefix of the description is enough to convey the meaning,
 the name may be made even shorter:
+
 ```lean
 import algebra.ordered_ring
 
 #check @neg_neg
 #check nat.pred_succ
 ```
+
 When an operation is written as infix, the theorem names follow
 suit. For example, we write `neg_mul_neg` rather than `mul_neg_neg` to
 describe the patter `-a * -b`.
@@ -289,6 +296,7 @@ describe the patter `-a * -b`.
 Sometimes, to disambiguate the name of theorem or better convey the
 intended reference, it is necessary to describe some of the
 hypotheses. The word "of" is used to separate these hypotheses:
+
 ```lean
 import algebra.ordered_ring
 open nat
@@ -297,6 +305,7 @@ open nat
 #check lt_of_le_of_ne
 #check add_lt_add_of_lt_of_le
 ```
+
 The hypotheses are listed in the order they appear, _not_ reverse
 order. For example, the theorem `A → B → C` would be named
 `C_of_A_of_B`.
@@ -304,6 +313,7 @@ order. For example, the theorem `A → B → C` would be named
 Sometimes abbreviations or alternative descriptions are easier to work
 with. For example, we use `pos`, `neg`, `nonpos`, `nonneg` rather than
 `zero_lt`, `lt_zero`, `le_zero`, and `zero_le`.
+
 ```lean
 import algebra.ordered_ring
 open nat
@@ -320,6 +330,7 @@ could be named either `add_sub_self` or `add_sub_cancel`.
 
 Sometimes the word "left" or "right" is helpful to describe variants
 of a theorem.
+
 ```lean
 import algebra.ordered_ring
 
@@ -329,12 +340,12 @@ import algebra.ordered_ring
 #check le_of_mul_le_mul_right
 ```
 
-## Naming of structural lemmas ##
+## Naming of structural lemmas
 
 We are trying to standardize certain naming patterns for structural lemmas.
 At present these are not uniform across mathlib.
 
-### Extensionality ###
+### Extensionality
 
 A lemma of the form `(∀ x, f x = g x) → f = g` should be named `.ext`,
 and labelled with the `@[ext]` attribute.
@@ -344,10 +355,9 @@ Often this type of lemma can be generated automatically by putting the
 of the structure projections, and often there is a better statement,
 e.g. using coercions, that should be written by hand then marked with `@[ext]`.)
 
-
 A lemma of the form `f = g ↔ ∀ x, f x = g x` should be named `.ext_iff`.
 
-### Injectivity ###
+### Injectivity
 
 Where possible, injectivity lemmas should be written in terms of an
 `injective f` conclusion which use the full word `injective`, typically as `f_injective`.

--- a/templates/contribute/style.md
+++ b/templates/contribute/style.md
@@ -1,4 +1,4 @@
-# Library Style Guidelines #
+# Library Style Guidelines
 Author: [Jeremy Avigad](http://www.andrew.cmu.edu/user/avigad)
 
 In addition to the [naming conventions](naming.html),
@@ -7,7 +7,7 @@ and conventions. Having a uniform style makes it easier to browse the
 library and read the contents, but these are meant to be guidelines
 rather than rigid rules.
 
-### Variable conventions ###
+### Variable conventions
 
 - `u`, `v`, `w`, ... for universes
 - `α`, `β`, `γ`, ... for generic types
@@ -27,12 +27,12 @@ This convention is not followed in older files, where greek letters are used
 for all types. Pull requests renaming type variables in these files are welcome.
 
 
-### Line length ###
+### Line length
 
 Lines should not be longer than 100 characters. This makes files
 easier to read, especially on a small screen or in a small window.
 
-### Header and imports ###
+### Header and imports
 
 The file header should contain copyright information, a list of all
 the authors who have made significant contributions to the file, and
@@ -250,7 +250,7 @@ instance : partial_order (topological_space α) :=
   le_trans    := assume a b c h₁ h₂, @le_trans _ _ a.is_open b.is_open c.is_open h₁ h₂ }
 ```
 
-### Hypotheses Left of Colon ###
+### Hypotheses Left of Colon
 
 Generally, having arguments to the left of the colon is preferred
 over having arguments in universal quantifiers or implications, 
@@ -278,7 +278,7 @@ is preferred over
 example : ∀ (n : ℕ), n ≥ 0 := λ n, dec_trivial
 ```
 
-### Binders ###
+### Binders
 
 Use a space after binders:
 ```lean
@@ -286,7 +286,7 @@ example : ∀ α : Type, ∀ x : α, ∃ y, y = x :=
 λ (α : Type) (x : α), exists.intro x rfl
 ```
 
-### Calculations ###
+### Calculations
 
 There is some flexibility in how you write calculational proofs. In
 general, it looks nice when the comparisons and justifications line up
@@ -325,7 +325,7 @@ theorem reverse_reverse : ∀ (l : list α), reverse (reverse l) = l
 ```
 
 
-### Tactic mode ###
+### Tactic mode
 
 When opening a tactic block, `begin` is not indented but everything
 inside is indented, as in:

--- a/templates/theories.md
+++ b/templates/theories.md
@@ -2,8 +2,8 @@
 
 The following document some theories spanning multiple files.
 
-* [Sets and set like objects](theories/sets.html)
-* [Categories](theories/category_theory.html)
+* [Sets and set-like objects](theories/sets.html)
+* [Category theory](theories/category_theory.html)
 * [Linear algebra](theories/linear_algebra.html)
 * [The natural numbers](theories/naturals.html)
 * [Topological, uniform and metric spaces](theories/topology.html)

--- a/templates/theories/category_theory.md
+++ b/templates/theories/category_theory.md
@@ -27,16 +27,19 @@ We use `𝟙` (`\b1`) to denote identity morphisms, as in `𝟙 X`.
 
 We use `≫` (`\gg`) to denote composition of morphisms, as in `f ≫ g`, which means "`f` followed by `g`".
 You may prefer write composition in the usual convention, using `⊚` (`\oo` or `\circledcirc`), as in `f ⊚ g` which means "`g` followed by `f`". To do so you'll need to add this notation locally, via
-```
+
+```lean
 local notation f ` ⊚ `:80 g:80 := category.comp g f
 ```
 
 ### Isomorphisms
+
 We use `≅` for isomorphisms.
 
 ### Functors
+
 We use `⥤` (`\func`) to denote functors, as in `C ⥤ D` for the type of functors from `C` to `D`.
-(Unfortunately `⇒` is reserved in `logic.relator`: https://github.com/leanprover-community/mathlib/blob/master/src/logic/relator.lean, so we can't use that here.)
+(Unfortunately `⇒` is reserved in [`logic.relator`](https://github.com/leanprover-community/mathlib/blob/master/src/logic/relator.lean), so we can't use that here.)
 
 We use `F.obj X` to denote the action of a functor on an object.
 We use `F.map f` to denote the action of a functor on a morphism`.
@@ -44,6 +47,7 @@ We use `F.map f` to denote the action of a functor on a morphism`.
 Functor composition can be written as `F ⋙ G`.
 
 ### Natural transformations
+
 We use `τ.app X` for the components of a natural transformation.
 
 Otherwise, we mostly use the notation for morphisms in any category:

--- a/templates/theories/category_theory.md
+++ b/templates/theories/category_theory.md
@@ -1,4 +1,4 @@
-# Maths in Lean : category theory
+# Maths in Lean: category theory
 
 The `category` typeclass is defined in [category_theory/default.lean](https://leanprover-community.github.io/mathlib_docs/category_theory/category/default.html).
 It depends on the type of the objects, so for example we might write `category (Type u)` if we're talking about a category whose objects are types (in universe `u`).

--- a/templates/theories/linear_algebra.md
+++ b/templates/theories/linear_algebra.md
@@ -1,4 +1,4 @@
-# Maths in lean : Linear Algebra
+# Maths in Lean: linear algebra
 
 ### Semimodules, Modules and Vector Spaces ###
 

--- a/templates/theories/linear_algebra.md
+++ b/templates/theories/linear_algebra.md
@@ -1,8 +1,8 @@
 # Maths in Lean: linear algebra
 
-### Semimodules, Modules and Vector Spaces ###
+### Semimodules, Modules and Vector Spaces
 
-#### [`algebra.module`](https://leanprover-community.github.io/mathlib_docs/algebra/module.html) ####
+#### [`algebra.module`](https://leanprover-community.github.io/mathlib_docs/algebra/module.html)
 
 This file defines the typeclass `semimodule R M`, which gives an `R`-semimodule structure on the type `M`, and similarly `module R M` and `vector_space R M`.
 An additive commutative monoid `M` is a semimodule over the semiring `R` if there is a scalar multiplication `•` (`has_scalar.smul`) that satisfies the expected distributivity axioms for `+` (in `M` and `R`) and `*` (in `R`).
@@ -25,9 +25,10 @@ The file [`linear_algebra.dimension`](https://leanprover-community.github.io/mat
 The `rank` of a linear map is defined as the dimension of its image.
 Most definitions in this file are non-computable.
 
-### Matrices ###
+### Matrices
 
-#### [`data.matrix.basic`](https://leanprover-community.github.io/mathlib_docs/data/matrix/basic.html) ####
+#### [`data.matrix.basic`](https://leanprover-community.github.io/mathlib_docs/data/matrix/basic.html)
+
 The type `matrix m n α` contains rectangular, `m` by `n` arrays of elements of the type `α`.
 It is an alias for the type `m → n → α`, under the assumptions `[fintype m] [fintype n]` stating that `m` and `n` have finitely many elements.
 A matrix type can be indexed over arbitrary `fintype`s.
@@ -60,9 +61,9 @@ The adjugate and for nonsingular matrices, the inverse is defined in [`linear_al
 The type `special_linear_group m R` is the group of `m` by `m` matrices with determinant `1`,
 and is defined in [`linear_algebra.special_linear_group`](https://leanprover-community.github.io/mathlib_docs/linear_algebra/special_linear_group.html).
 
-### Linear Maps and Equivalences ###
+### Linear Maps and Equivalences
 
-#### [`linear_algebra.basic`](https://leanprover-community.github.io/mathlib_docs/linear_algebra/basic.html) ####
+#### [`linear_algebra.basic`](https://leanprover-community.github.io/mathlib_docs/linear_algebra/basic.html)
 
 The type `M →[R]ₗ M₂`, or `linear_map R M M₂`, represents `R`-linear maps from the `R`-module `M` to the `R`-mdule `M₂`.
 These are defined by their action on elements of `M`.
@@ -87,21 +88,21 @@ The type [`general_linear_group R M`](https://leanprover-community.github.io/mat
 
 The dual space, consisting of linear maps `M →[R]ₗ R`, is defined in [`linear_algebra.dual`](https://leanprover-community.github.io/mathlib_docs/linear_algebra/dual.html).
 
-### Bilinear, Sesquilinear and Quadratic Forms ###
+### Bilinear, Sesquilinear and Quadratic Forms
 
-#### [`linear_algebra.bilinear_form`](https://leanprover-community.github.io/mathlib_docs/linear_algebra/bilinear_form.html) ####
+#### [`linear_algebra.bilinear_form`](https://leanprover-community.github.io/mathlib_docs/linear_algebra/bilinear_form.html)
 
 For an `R`-module `M`, the type `bilin_form R M` is the type of maps `M → M → R` that are linear in both arguments.
 The equivalence between `bilin_form R M` and maps `M →ₗ[R] M →ₗ[R] R` that are linear in both arguments is called `bilin_linear_map_equiv`.
 A matrix `M` corresponds to a bilinear form that maps vectors `v` and `w` to `row v ⬝ M ⬝ col w`.
 The equivalence between `bilin_form R (n → R)` and `matrix n n R` is called [`bilin_form_equiv_matrix`](https://leanprover-community.github.io/mathlib_docs/linear_algebra/bilinear_form.html#bilin_form_equiv_matrix).
 
-#### [`linear_algebra.sesquilinear_form`](https://leanprover-community.github.io/mathlib_docs/linear_algebra/sesquilinear_form.html) ####
+#### [`linear_algebra.sesquilinear_form`](https://leanprover-community.github.io/mathlib_docs/linear_algebra/sesquilinear_form.html)
 
 For an `R`-module `M` and `I : ring_anti_equiv R R`, the type `sesq_form R M I` is the type of maps `M → M → R` that are linear in the first argument and that in the second argument are antilinear with respect to an `R`-[antiautomorphism](https://leanprover-community.github.io/mathlib_docs/ring_theory/maps.html#ring_anti_equiv) `I`.
 Antilinearity of `f` with respect to a ring antiautomorphism `I` means the following equations hold: `f x (a • y) = I a * f x y`, `I 1 = 1`, `I (x + y) = I x + I y` and `I (x * y) = I y * I x`.
 
-#### [`linear_algebra.quadratic_form`](https://leanprover-community.github.io/mathlib_docs/linear_algebra/quadratic_form.html) ####
+#### [`linear_algebra.quadratic_form`](https://leanprover-community.github.io/mathlib_docs/linear_algebra/quadratic_form.html)
 
 For an `R`-module `M`, the type `quadratic_form R M` is the type of maps `f : M → R` such that `f (a • x) = a * a * f x` and `λ x y, f (x + y) - f x - f y` is a bilinear map.
 

--- a/templates/theories/naturals.md
+++ b/templates/theories/naturals.md
@@ -1,4 +1,4 @@
-# Maths in Lean : the natural numbers
+# Maths in Lean: the natural numbers
 
 The natural numbers begin with zero as is standard in computer
 science. You can call them `nat` or `ℕ` (you get the latter

--- a/templates/theories/naturals.md
+++ b/templates/theories/naturals.md
@@ -11,9 +11,9 @@ takes a natural as input and outputs the next one.
 
 Addition and multiplication are defined by recursion on the second
 variable and many proofs of basic stuff in the core library are by
-induction on the second variable. The notations `+,-,*` are shorthand
-for the functions `nat.add`, `nat.sub` and `nat.mul` and other notations
-(≤, <, |) mean the usual things (get the "divides" symbol with `\|`.
+induction on the second variable. The notations `+`, `-`, `*` are shorthand
+for the functions `nat.add`, `nat.sub` and `nat.mul`, and other notations
+(`≤`, `<`, `|`) mean the usual things (get the "divides" symbol with `\|`).
 The `%` symbol denotes modulus (remainder after division).
 
 Here are some of core Lean's functions for working with `nat`.

--- a/templates/theories/sets.md
+++ b/templates/theories/sets.md
@@ -1,40 +1,50 @@
 # Maths in Lean: Sets and set-like objects
 
-### Lists ###
-#### `data.list.basic` ####
+### Lists
+
+#### `data.list.basic`
+
 `list α` is the type of lists of elements of type α. Lists are finite and ordered, and can contain duplicates. Lists can only contain elements of the same type. Lists are constructed using the cons function, which appends an element of α to the top of a list. Lists are discussed in more detail in TPIL, chapter 7.5
 
 `[1, 1, 2, 4] ≠ [1, 2, 1, 4]`
 
 `[1, 2, 1, 4] ≠ [1, 2, 4]`
 
-### Multisets ###
-#### `data.multiset` #####
+### Multisets
+
+#### `data.multiset`
+
 `multiset α` is the type of multisets of elements of type α. Multisets are finite and can contain duplicates, but are not ordered. They are defined as the quotient of lists over the `perm` equivalence relation. Multisets can only contain elements of the same type.
 
 `{1, 1, 2, 4} = {1, 2, 1, 4}`
 
 `{1, 1, 2, 4} ≠ {1, 2, 4}`
 
-### Finsets ###
-#### `data.finset` ####
+### Finsets
+
+#### `data.finset`
+
 `finset α` is the type of unordered lists of distinct elements of type α. A finset is contructed from a multiset and a proof that the multiset contains no duplicates. Finsets are finite. Finsets can only contain elements of the same type.
 
 `{1, 1, 2, 4} = {1, 2, 1, 4}`
 
 `{1, 1, 2, 4} = {1, 2, 4}`
 
-### Sets and subtypes ###
-#### `data.set.basic` ####
+### Sets and subtypes
+
+#### `data.set.basic`
+
 `set α`. A set is defined as a predicate, i.e. a function `α → Prop`. The notation used is `{n : ℕ | 4 ≤ n}` for the set of naturals greater than or equal to 4. Sets can be infinite, and can only contain elements of the same type.
 
 A subtype is similar to a set in that it is defined by a predicate. The notation used is `{n : ℕ // 4 ≤ n}` for the type of naturals greater than or equal to 4. However, a subtype is a type rather than a set, and the elements the aforementioned subtype do not have type `ℕ`, they have type `{n : ℕ // 4 ≤ n}`. This means that addition is not defined on this type, and equality between naturals and this type is also undefined. However it is possible to coerce an element of this subtype back into a natural, in the same way that a natural can be coerced into an integer, and then addition and equality behave as normal (see TPIL, chapter 6.7 for more on coercions). To construct an element of a subtype of α, you need an element of α and a proof that it satisfies the predicate, `4` and ``le_refl 4`` in the example below.
+
 ```lean
 def x : {n : ℕ // 4 ≤ n} := ⟨4, le_refl 4⟩
 example : ↑x + 6 = 10 := rfl
 ```
 
 Any set can be used where a type is expected, in which case the set will be coerced into the corresponding subtype.
+
 ```lean
 def S : set ℕ := {n : ℕ | 4 ≤ n}
 example : ∀ n : S, 4 ≤ (n : ℕ) := λ ⟨n, hn⟩, hn
@@ -42,33 +52,44 @@ example : ∀ n : S, 4 ≤ (n : ℕ) := λ ⟨n, hn⟩, hn
 
 It is useful to use a subtype rather than a set when you need to define functions on subtypes, or when using the cardinal of a subtype.
 
-### Finite types ###
-#### `data.fintype.basic` ####
+### Finite types
+
+#### `data.fintype.basic`
+
 `fintype α` means that a type α is finite. It is constructed from a finset containing all elements of a type.
+
 ```lean
 class fintype (α : Type*) :=
 (elems : finset α)
 (complete : ∀ x : α, x ∈ elems)
 ```
+
 `fintype α` is not a proposition, because it contains data, however it is a subsingleton, meaning that any two elements of type `fintype α` are equal.
 
 `finset.univ` is the finset containing all elements of a type, given a `fintype α` instance.
 
-### Finite sets ###
-#### `data.set.finite` ####
+### Finite sets
+
+#### `data.set.finite`
+
 The definition of a finite set, distinct from a finset is
+
 ```lean
 def finite (s : set α) : Prop := nonempty (fintype s)
 ```
+
 This means when the set is coerced into a subtype, the type `fintype s` is nonempty.
 Using `classical.choice`, you can produce an object of type `fintype s` from a proof of `finite s`. There is a function `set.finite.to_finset` which produces a finset from a finite set.
 
-### Cardinals ###
+### Cardinals
+
 There are three functions `finset.card`, `fintype.card` and `multiset.card`, which refer to the sizes of finsets, multisets and finite types. For finite cardinals of sets, `fintype.card` can be used, given a proof that the set is finite.
+
 ```lean
 example : ∀ n : ℕ, fintype.card (fin n) = n := fintype.card_fin
 example : ∀ n : ℕ, finset.card (finset.range n) = n := finset.card_range
 ```
+
 Here, `fin n` is the type of naturals less than n, and `finset.range n` is the finset of naturals less than n.
 
 `set_theory.cardinal` contains theory on infinite cardinals

--- a/templates/theories/sets.md
+++ b/templates/theories/sets.md
@@ -1,4 +1,4 @@
-# Maths in lean : set-like objects
+# Maths in Lean: Sets and set-like objects
 
 ### Lists ###
 #### `data.list.basic` ####

--- a/templates/theories/topology.md
+++ b/templates/theories/topology.md
@@ -1,4 +1,4 @@
-# Maths in lean : Topological Spaces.
+# Maths in Lean: Topological, uniform and metric spaces
 
 The `topological_space` typeclass is defined in mathlib,
 in `topology/basic.lean`. There are about 18000
@@ -8,7 +8,7 @@ topological groups and rings, and infinite sums. These docs
 are just concerned with the contents of the `topological_space.lean`
 file.
 
-### The basic typeclass.
+### The basic typeclass
 
 The `topological_space` typeclass is an inductive type, defined
 as a structure on a type `α` in the obvious way: there is an `is_open`

--- a/templates/theories/topology.md
+++ b/templates/theories/topology.md
@@ -92,6 +92,7 @@ Why are we interested in these filters? Well, given a map `f` from `ℕ` to a to
 
 As an example, below are three limits formulated in Lean.
 The example uses the filters `at_top` and `at_bot` that represent "tends to `∞`" and "tends to `-∞`" in a type equipped with an order.
+
 ```lean
 -- The limit of `2 * x` as `x` tends to `3` is `6`
 example : tendsto (λ x : ℝ, 2 * x) (𝓝 3) (𝓝 6) := sorry
@@ -100,7 +101,6 @@ example : tendsto (λ x : ℝ, 1 / x) at_top (𝓝 0) := sorry
 -- The limit of `x ^ 2` as `x` tends to `-∞` is `∞`
 example : tendsto (λ x : ℝ, x ^ 2) at_bot at_top := sorry
 ```
-
 
 The _principal filter_ `principal Y` attached to a subset `Y` of a set `X` is the collection of all subsets of `X` that contain `Y`. So it's not difficult to convince yourself that the following results should be true:
 


### PR DESCRIPTION
Normalize titles of pages in [theories/](https://github.com/leanprover-community/leanprover-community.github.io/tree/newsite/templates/theories):

- Capitalize 'Lean'
- Remove space before ':'
- Normalize capitalization
- Sync the in-page titles with those in theories.md
- Replace a non-breaking space character with a regular one

Also, apply various small Markdown fixes to pages in [theories/](https://github.com/leanprover-community/leanprover-community.github.io/tree/newsite/templates/theories) and [contribute/](https://github.com/leanprover-community/leanprover-community.github.io/tree/newsite/templates/contribute):

- Use a blank line to separate blocks (headings, paragraphs, code blocks, etc.)
- Normalize headings to the non-wrapped style (which is more prevalent in this repo)
- Add missing language specifications for fenced code blocks
- Fix a raw URL to be a proper markdown link
- Add missing backticks and other punctuation in `theories/naturals.md`

