### PR TITLE
lean.bib: add paper on Dedekind domains and class groups

### DIFF
--- a/lean.bib
+++ b/lean.bib
@@ -53,6 +53,19 @@
   tags		= {about-mathlib, lean3}
 }
 
+@Misc{		  BaanenDahmenNarayananNuccio21,
+  title		= {A formalization of {D}edekind domains and class groups of global fields},
+  author	= {Anne Baanen and Sander R. Dahmen and Ashvni Narayanan and Filippo A. E. Nuccio},
+  year		= {2021},
+  eprint	= {2102.02600},
+  archiveprefix	= {arXiv},
+  primaryclass	= {cs.LO},
+  url           = {https://arxiv.org/abs/2102.02600},
+  website	= {https://github.com/lean-forward/class_number},
+  tags		= {formalization, lean3},
+  note          = {To be presented at ITP 2021},
+}
+
 @InProceedings{	  Buch18,
   author	= {Ulrik Buchholtz and Floris {van Doorn} and Egbert Rijke},
   title		= {Higher Groups in Homotopy Type Theory},


### PR DESCRIPTION
Add our paper "A formalization of Dedekind domains and class groups of global fields", to be presented at ITP 2021, to the bibliography file. Once the paper is published, I'll update the reference to a full `InProceedings`.