### PR TITLE
fix(templates/contribute/doc): delete line break in documentation style guideline 

### DIFF
--- a/templates/contribute/doc.md
+++ b/templates/contribute/doc.md
@@ -44,7 +44,6 @@ Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
 -/
-
 import data.rat
 import algebra.gcd_domain
 import algebra.field_power


### PR DESCRIPTION
The code style guideline states, " Do all imports right after the header, without a line break," but here there is a line break.