### PR TITLE
doc(templates/contribute): update doc_blame linter documentation

### DIFF
--- a/templates/contribute/doc.md
+++ b/templates/contribute/doc.md
@@ -126,8 +126,28 @@ then (multiplicity (p : ℤ) q.num).get
 else 0
 ```
 
-The `#doc_blame` command can be run at the bottom of a file to list all definitions that do not have
-doc strings. `#doc_blame!` will also list theorems and lemmas.
+The `doc_blame` linter lists all definitions that do not have doc strings. The `doc_blame_thm` 
+linter will lists theorems and lemmas that do not have doc strings.
+
+To run only the `doc_blame` linter, add the following to the end of your lean file:
+```
+#lint only doc_blame
+```
+To run only the `doc_blame` and `doc_blame_thm` linters, add the following to the end of your lean 
+file:
+```
+#lint only doc_blame doc_blame_thm
+```
+To run the all default linters, including `doc_blame`, add the following to the end of your lean 
+file:
+```
+#lint
+```
+To run the all default linters, including `doc_blame` and run `doc_blame_thm`, add the following to 
+the end of your lean file:
+```
+#lint doc_blame_thm
+```
 
 ## LaTeX and Markdown
 


### PR DESCRIPTION
The current [doc-strings contribute guidelines](https://leanprover-community.github.io/contribute/doc.html#doc-strings) refer to the `doc_blame` and `doc_blame!` commands which no longer exist. This is confusing for newcomers.

This PR updates the documentation to refer to the linters which replace these commands, and explains how they may be used by the reader who may not be familiar with the `lint` command.