### PR TITLE
Add a touch of color.

### DIFF
--- a/css/lean.css
+++ b/css/lean.css
@@ -8264,3 +8264,12 @@ pre {
 
 .break_within .name {
   word-break: normal; }
+
+.paper-tag-lean2 {
+  background-color: #d39e00; }
+
+.paper-tag-lean3 {
+  background-color: #0062cc; }
+
+.paper-tag-lean4 {
+  background-color: var(--green); }

--- a/make_site.py
+++ b/make_site.py
@@ -343,6 +343,7 @@ def render_site(target: Path, base_url: str, reloader=False):
         content_template = env.get_template("_markdown.html")
         path = Path(template.name)
         title = path.with_suffix('').name
+        (target/path.parent).mkdir(parents=True, exist_ok=True)
         content_template.stream(**kwargs).dump(str(target/path.parent/title)+'.html')
 
     def get_contents(template):

--- a/make_site.py
+++ b/make_site.py
@@ -16,6 +16,7 @@ from pylatexenc.latex2text import LatexNodes2Text
 import urllib.request
 import json
 import gzip
+import os
 from github import Github
 
 class MarkdownExtension(jinja2.ext.Extension):
@@ -241,7 +242,7 @@ class Project:
     maintainers: List[str]
     stars: int
 
-github = Github()
+github = Github(os.environ.get('GITHUB_TOKEN', None))
 
 urllib.request.urlretrieve(
     'https://leanprover-contrib.github.io/leanprover-contrib/projects/projects.yml',

--- a/scss/lean.scss
+++ b/scss/lean.scss
@@ -156,3 +156,7 @@ pre {
 .break_within .name {
     word-break: normal;
 }
+
+.paper-tag-lean2 { background-color: darken($yellow, 10%); }
+.paper-tag-lean3 { background-color: darken($blue, 10%); }
+.paper-tag-lean4 { background-color: var(--green); }

--- a/templates/papers.html
+++ b/templates/papers.html
@@ -13,7 +13,7 @@
           {{ paper.fields['year'] }}
           {% if 'website' in paper.fields %} (<a href="{{ paper.fields['website'] }}">website</a>){% endif %}
           {% for tag in paper.fields['tags'] %}
-          <small class="align-middle"><span class="badge badge-secondary align-middle">{{ tag }}</span></small>
+          <small class="align-middle"><span class="badge badge-secondary align-middle paper-tag-{{tag}}">{{ tag }}</span></small>
           {% endfor %}
         </li>
         {% endfor %}


### PR DESCRIPTION
![touchofcolor](https://user-images.githubusercontent.com/313929/135324041-57874410-25b8-47ae-b4a8-50a739c4e61e.png)

This makes it much easier to visually group the papers into the various eras.  The color for Lean 4 is derived from :four_leaf_clover:, of course.
