### PR TITLE
Fix incorrect class number paper link

### DIFF
--- a/lean.bib
+++ b/lean.bib
@@ -65,7 +65,7 @@
   archiveprefix = {arXiv},
   primaryclass  = {cs.LO},
   url           = {https://arxiv.org/abs/2102.02600},
-  website       = {https://github.com/lean-forward/class_number},
+  website       = {https://github.com/lean-forward/class-number},
   tags          = {formalization, lean3},
   note          = {To be presented at ITP 2021}
 }


### PR DESCRIPTION
The link pointed to `class_number` when it should be `class-number`.