### PR TITLE
Add a link to the import graph

### DIFF
--- a/templates/mathlib_stats.html
+++ b/templates/mathlib_stats.html
@@ -44,7 +44,7 @@
 
     <h2>Dependency graph</h2>
 
-    <p>A visualization showing how the various topics in mathlib interact and their relative sizes can be found <a href="https://eric-wieser.github.io/mathlib-import-graph">here</p>
+    <p>A visualization showing how the various topics in mathlib interact and their relative sizes can be found <a href="https://eric-wieser.github.io/mathlib-import-graph">here</a>.</p>
 {% endblock %}
 
 {% block extrajs %}

--- a/templates/mathlib_stats.html
+++ b/templates/mathlib_stats.html
@@ -42,6 +42,9 @@
 
       <canvas id="commits_by_authors"></canvas>
 
+    <h2>Dependency graph</h2>
+
+    <p>A visualization showing how the various topics in mathlib interact and their relative sizes can be found <a href="https://eric-wieser.github.io/mathlib-import-graph">here</p>
 {% endblock %}
 
 {% block extrajs %}


### PR DESCRIPTION
Putting this up for discussion. We could also consider embedding the graph, but then we'd need some way to strip the UI elements that won't scale well.

We might want this under the `leanprover-community` org if we plan to embed it.