### PR TITLE
"continuum hypothesis" -> "independence of the continuum hypothesis"

### DIFF
--- a/data/formalizations.yaml
+++ b/data/formalizations.yaml
@@ -23,7 +23,7 @@
             proof about simple objects.
   url: https://leanprover-community.github.io/lean-perfectoid-spaces/
 -
-  title: The continuum hypothesis
+  title: Independence of the continuum hypothesis
   authors: Han and van Doorn
   abstract: |
             The continuum hypothesis states that there is no cardinality between


### PR DESCRIPTION
For me, "continuum hypothesis" could mean something as weak as "we stated the continuum hypothesis" (indeed "perfectoid spaces" above it means "we stated the definition of a perfectoid space"). Of all the questions one could possibly ask about the continuum hypothesis, independence is probably the hardest one; it's a highly nontrivial piece of mathematics which got Cohen a Fields Medal. I think we should stress that this is what was done.