### PR TITLE
M1 installation instructions using the x86 build of Lean

### DIFF
--- a/templates/install/macos.md
+++ b/templates/install/macos.md
@@ -42,7 +42,7 @@ The following instructions are adapted from [Fedor Pavutnitskiy](https://leanpro
 
 3. Install a second installation of Homebrew for `x86` with `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`. It will automatically install itself into a second location (`/usr/local`, rather than `/opt/`).
 
-4. The same steps as described in [controlled installation for macos](https://leanprover-community.github.io/install/macos_details.html) using the brew you just installed:
+4. Follow the same steps described in [Controlled Installation for macOS](https://leanprover-community.github.io/install/macos_details.html) using the `brew` you just installed:
 
 ```
 /usr/local/bin/brew install elan mathlibtools

--- a/templates/install/macos.md
+++ b/templates/install/macos.md
@@ -50,7 +50,7 @@ elan toolchain install stable
 elan default stable  
 ```
 
-5. Install vs-code from the website and set it up as usual.
+5. Install Visual Studio Code and the Lean extension via `brew install --cask visual-studio-code && code --install-extension jroesch.lean`.
 
 There is a [Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/M1.20macs)
 with some interim further details and advice. If you have trouble, feel free to ask for help.

--- a/templates/install/macos.md
+++ b/templates/install/macos.md
@@ -30,13 +30,31 @@ Given that GitHub Actions does [not yet support builds on Apple
 ARM](https://github.com/actions/virtual-environments/issues/2187), installation
 of Lean is for the moment a bit more complex.
 
-Specifically, `elan` – which is otherwise recommended (and installed)
+Specifically, `elan` – which is installed
 as part of the above instructions – will not be able to fetch Lean binaries on
-these devices.
+these devices if installed the normal way.
 
-Until [a separate M1 installation is
-automated](https://github.com/leanprover-community/mathlib-tools/issues/107),
-manual compilation of Lean is required on Apple ARM hardware.
+The following instructions are adapted from [Fedor Pavutnitskiy](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/M1.20Macs.3A.20Installing.20the.20Lean.203.20toolchain/near/262832039), and allow you to install elan through [Rosetta](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment).
+
+1. Open new terminal window and install xcode command line tools and rosetta 2 using ```xcode-select --install``` and ```softwareupdate --install-rosetta```.
+
+2. Switch to the x86 architechture in the current terminal window by ```arch -x86_64 zsh ``` as boris suggests. Everything below should happen in the same window.
+
+3. Install brew with ```/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"```
+
+4. The same steps as described in [controlled installation for macos](https://leanprover-community.github.io/install/macos_details.html) using the brew you just installed:
+
+```
+/usr/local/bin/brew install elan mathlibtools
+elan toolchain install stable 
+elan default stable  
+```
+
+5. Use ```leanproject get``` to get the repositories needed.
+
+6. Install vs-code from the website and set it up as usual.
+
+```leanproject``` should always be called from ```arch -x86_64```. Also, there may be some performance downsides to using lean under rosetta vs natively.
 
 There is a [Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/M1.20macs)
 with some interim further details and advice. If you have trouble, feel free to ask for help.

--- a/templates/install/macos.md
+++ b/templates/install/macos.md
@@ -50,7 +50,7 @@ elan toolchain install stable
 elan default stable  
 ```
 
-5. Install Visual Studio Code and the Lean extension via `brew install --cask visual-studio-code && code --install-extension jroesch.lean`.
+5. Install Visual Studio Code and the Lean extension via `brew install --cask visual-studio-code && code --install-extension jroesch.lean` (both the x86 and ARM versions of `brew` should work).
 
 There is a [Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/M1.20macs)
 with some interim further details and advice. If you have trouble, feel free to ask for help.

--- a/templates/install/macos.md
+++ b/templates/install/macos.md
@@ -54,8 +54,6 @@ elan default stable
 
 6. Install vs-code from the website and set it up as usual.
 
-```leanproject``` should always be called from ```arch -x86_64```. Also, there may be some performance downsides to using lean under rosetta vs natively.
-
 There is a [Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/M1.20macs)
 with some interim further details and advice. If you have trouble, feel free to ask for help.
 

--- a/templates/install/macos.md
+++ b/templates/install/macos.md
@@ -50,9 +50,7 @@ elan toolchain install stable
 elan default stable  
 ```
 
-5. Use ```leanproject get``` to get the repositories needed.
-
-6. Install vs-code from the website and set it up as usual.
+5. Install vs-code from the website and set it up as usual.
 
 There is a [Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/M1.20macs)
 with some interim further details and advice. If you have trouble, feel free to ask for help.

--- a/templates/install/macos.md
+++ b/templates/install/macos.md
@@ -40,7 +40,7 @@ The following instructions are adapted from [Fedor Pavutnitskiy](https://leanpro
 
 2. We will install a second, separate x86 installation of Homebrew, which is easiest done by running a shell entirely using Rosetta 2. Do so by running `arch -x86_64 zsh`. The remainder of the commands below should be run from within this `x86`-running window, though once the steps have been completed, the installed tools will work in any future shell.
 
-3. Install brew with ```/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"```
+3. Install a second installation of Homebrew for `x86` with `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`. It will automatically install itself into a second location (`/usr/local`, rather than `/opt/`).
 
 4. The same steps as described in [controlled installation for macos](https://leanprover-community.github.io/install/macos_details.html) using the brew you just installed:
 

--- a/templates/install/macos.md
+++ b/templates/install/macos.md
@@ -38,7 +38,7 @@ The following instructions are adapted from [Fedor Pavutnitskiy](https://leanpro
 
 1. Open a new terminal window and install XCode Command Line Tools and Rosetta 2 using `xcode-select --install` and `softwareupdate --install-rosetta`.
 
-2. Switch to the x86 architechture in the current terminal window by ```arch -x86_64 zsh ``` as boris suggests. Everything below should happen in the same window.
+2. We will install a second, separate x86 installation of Homebrew, which is easiest done by running a shell entirely using Rosetta 2. Do so by running `arch -x86_64 zsh`. The remainder of the commands below should be run from within this `x86`-running window, though once the steps have been completed, the installed tools will work in any future shell.
 
 3. Install brew with ```/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"```
 

--- a/templates/install/macos.md
+++ b/templates/install/macos.md
@@ -36,7 +36,7 @@ these devices if installed the normal way.
 
 The following instructions are adapted from [Fedor Pavutnitskiy](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/M1.20Macs.3A.20Installing.20the.20Lean.203.20toolchain/near/262832039), and allow you to install elan through [Rosetta](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment).
 
-1. Open new terminal window and install xcode command line tools and rosetta 2 using ```xcode-select --install``` and ```softwareupdate --install-rosetta```.
+1. Open a new terminal window and install XCode Command Line Tools and Rosetta 2 using `xcode-select --install` and `softwareupdate --install-rosetta`.
 
 2. Switch to the x86 architechture in the current terminal window by ```arch -x86_64 zsh ``` as boris suggests. Everything below should happen in the same window.
 


### PR DESCRIPTION
I am updating the M1 installation description with some instructions from the "M1 Macs: Installing the Lean 3 toolchain" thread. These instructions worked for me and others as of today.