### PR TITLE
Add opensearch support to the mathlib docs

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -7,6 +7,7 @@
 
   <link rel="stylesheet" href="{{base_url}}/css/lean.css" >
   <link rel="shortcut icon" href="{{base_url}}/img/favicon.ico">
+  <link rel="search" type="application/opensearchdescription+xml" title="mathlib docs" href="/opensearch.xml">
 <link href="https://fonts.googleapis.com/css2?family=Merriweather&family=Open+Sans&family=Source+Code+Pro:wght@400;600&display=swap" rel="stylesheet">
     {% block extracss %}{% endblock %}
 

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -7,7 +7,7 @@
 
   <link rel="stylesheet" href="{{base_url}}/css/lean.css" >
   <link rel="shortcut icon" href="{{base_url}}/img/favicon.ico">
-  <link rel="search" type="application/opensearchdescription+xml" title="mathlib docs" href="/opensearch.xml">
+  <link rel="search" type="application/opensearchdescription+xml" title="mathlib docs" href="{{base_url}}/opensearch.xml">
 <link href="https://fonts.googleapis.com/css2?family=Merriweather&family=Open+Sans&family=Source+Code+Pro:wght@400;600&display=swap" rel="stylesheet">
     {% block extracss %}{% endblock %}
 

--- a/templates/opensearch.xml
+++ b/templates/opensearch.xml
@@ -1,9 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
   <ShortName>mathlib</ShortName>
   <Description>Search mathlib docs</Description>
   <InputEncoding>UTF-8</InputEncoding>
   <Image width="16" height="16" type="image/x-icon">{{base_url}}/img/favicon.ico</Image>
-  <Url type="application/x-suggestions+json" method="GET" template="http://suggestqueries.google.com/complete/search?output=firefox&amp;q={searchTerms}" />
   <Url type="text/html" method="GET" template="{{base_url}}/mathlib_docs/find/{searchTerms}" />
-  <SearchForm>{{base_url}}/mathlib_docs</SearchForm>
 </OpenSearchDescription>

--- a/templates/search.xml
+++ b/templates/search.xml
@@ -1,0 +1,9 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>mathlib</ShortName>
+  <Description>Search mathlib docs</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/x-icon">{{base_url}}/img/favicon.ico</Image>
+  <Url type="application/x-suggestions+json" method="GET" template="http://suggestqueries.google.com/complete/search?output=firefox&amp;q={searchTerms}" />
+  <Url type="text/html" method="GET" template="{{base_url}}/mathlib_docs/find/{searchTerms}" />
+  <SearchForm>{{base_url}}/mathlib_docs</SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
This should make supported browsers offer a "search mathlib docs" feature in the title bar.

It's not clear to me whether this will work in the mathlib doc repo, there are rumors online that it has to be at the site root.

I'll make a PR there anyway to test (https://github.com/leanprover-community/doc-gen/pull/161)