### PR TITLE
Add row numbering to table mathlib_stats table

### DIFF
--- a/templates/mathlib_stats.html
+++ b/templates/mathlib_stats.html
@@ -154,6 +154,7 @@ window.onload = function() {
         responsiveLayout:true,
         columns: authors_cols,
         height: "600px",
+        formatter:"rownum",
     });
     table.redraw(true);
 


### PR DESCRIPTION
I think this code will [number the rows in the table](http://tabulator.info/docs/5.3/format#formatter-rownum), so that we stop needing a column for "# by commits".