### PR TITLE
doc(style): improve Normal forms section

### DIFF
--- a/templates/contribute/style.md
+++ b/templates/contribute/style.md
@@ -443,7 +443,7 @@ conclusions of theorems. In the above examples, this would be `s.nonempty` (whic
 gives access to dot notation) and `(a : option α)`. Often, simp lemmas will be
 registered to convert the other equivalent forms to the normal form.
 
-There is an exception to this rule. In types with a bottom element, it is equivalent
+There is a special case to this rule. In types with a bottom element, it is equivalent
 to require `hlt : ⊥ < x` or `hne : x ≠ ⊥`, and it is not clear which one would be
 better as a normal form since both have their pros and cons. An analogous situation
 occurs with `hlt : x < ⊤` and `hne : x ≠ ⊤` in types with a top element. Since it is

--- a/templates/contribute/style.md
+++ b/templates/contribute/style.md
@@ -450,8 +450,8 @@ occurs with `hlt : x < ⊤` and `hne : x ≠ ⊤` in types with a top element. S
 easy to convert from `hlt` to `hne` (by using `hlt.ne` or `hlt.ne'` depending
 on the direction we want) while the other conversion is more lengthy, we use `hne` in
 *assumptions* of theorems (as this is the easier assumption to check), and `hlt` in 
-*conclusions* of theorems (as this is the more powerful result to use). A common
-usage of this rule is with naturals, where `⊥ = 0`.
+*conclusions* of theorems (as this is the more powerful result to use). 
+A common usage of this rule is with naturals, where `⊥ = 0`.
 
 ## Comments
 

--- a/templates/contribute/style.md
+++ b/templates/contribute/style.md
@@ -444,8 +444,8 @@ gives access to dot notation) and `(a : option α)`. Often, simp lemmas will be
 registered to convert the other equivalent forms to the normal form.
 
 There is a special case to this rule. In types with a bottom element, it is equivalent
-to require `hlt : ⊥ < x` or `hne : x ≠ ⊥`, and it is not clear which one would be
-better as a normal form since both have their pros and cons. An analogous situation
+to require `hlt : ⊥ < x` or `hne : x ≠ ⊥`, and it is not clear which one would 
+be better as a normal form since both have their pros and cons. An analogous situation
 occurs with `hlt : x < ⊤` and `hne : x ≠ ⊤` in types with a top element. Since it is
 very easy to convert from `hlt` to `hne` (by using `hlt.ne` or `hlt.ne'` depending
 on the direction we want) while the other conversion is more lengthy, we use `hne` in

--- a/templates/contribute/style.md
+++ b/templates/contribute/style.md
@@ -448,8 +448,8 @@ to require `hlt : ⊥ < x` or `hne : x ≠ ⊥`, and it is not clear which one w
 be better as a normal form since both have their pros and cons. An analogous situation
 occurs with `hlt : x < ⊤` and `hne : x ≠ ⊤` in types with a top element. Since it is very 
 easy to convert from `hlt` to `hne` (by using `hlt.ne` or `hlt.ne'` depending
-on the direction we want) while the other conversion is more lengthy, we use `hne` in 
-*assumptions* of theorems (as this is the easier assumption to check), and `hlt` in
+on the direction we want) while the other conversion is more lengthy, we use `hne` in
+*assumptions* of theorems (as this is the easier assumption to check), and `hlt` in 
 *conclusions* of theorems (as this is the more powerful result to use). A common
 usage of this rule is with naturals, where `⊥ = 0`.
 

--- a/templates/contribute/style.md
+++ b/templates/contribute/style.md
@@ -443,14 +443,15 @@ conclusions of theorems. In the above examples, this would be `s.nonempty` (whic
 gives access to dot notation) and `(a : option α)`. Often, simp lemmas will be
 registered to convert the other equivalent forms to the normal form.
 
-Here is a special case to this rule. When `n` is a natural number,
-it is equivalent to require `hlt : 0 < n` or `hne : n ≠ 0`, and it is not clear which one would
-be better as a normal form since both have their pros and cons. Since it is very
-easy to convert from `hlt` to `hne` (by using `hlt.ne` or `hlt.ne'` depending
+There is an exception to this rule. In types with a bottom element, it is equivalent
+to require `hlt : ⊥ < x` or `hne : x ≠ ⊥`, and it is not clear which one would be
+better as a normal form since both have their pros and cons. An analogous situation
+occurs with `hlt : x < ⊤` and `hne : x ≠ ⊤` in types with a top element. Since it is
+very easy to convert from `hlt` to `hne` (by using `hlt.ne` or `hlt.ne'` depending
 on the direction we want) while the other conversion is more lengthy, we use `hne` in
-*assumptions* of theorems (as this is the easier assumption to check), and `hlt` in 
-*conclusions* of theorems (as this is the more powerful result to use). 
-The same rule holds in all ordered type with a bottom or a top element.
+*assumptions* of theorems (as this is the easier assumption to check), and `hlt` in
+*conclusions* of theorems (as this is the more powerful result to use). A common
+usage of this rule is with naturals, where `⊥ = 0`.
 
 ## Comments
 

--- a/templates/contribute/style.md
+++ b/templates/contribute/style.md
@@ -446,9 +446,9 @@ registered to convert the other equivalent forms to the normal form.
 There is a special case to this rule. In types with a bottom element, it is equivalent
 to require `hlt : ⊥ < x` or `hne : x ≠ ⊥`, and it is not clear which one would 
 be better as a normal form since both have their pros and cons. An analogous situation
-occurs with `hlt : x < ⊤` and `hne : x ≠ ⊤` in types with a top element. Since it is
-very easy to convert from `hlt` to `hne` (by using `hlt.ne` or `hlt.ne'` depending
-on the direction we want) while the other conversion is more lengthy, we use `hne` in
+occurs with `hlt : x < ⊤` and `hne : x ≠ ⊤` in types with a top element. Since it is very 
+easy to convert from `hlt` to `hne` (by using `hlt.ne` or `hlt.ne'` depending
+on the direction we want) while the other conversion is more lengthy, we use `hne` in 
 *assumptions* of theorems (as this is the easier assumption to check), and `hlt` in
 *conclusions* of theorems (as this is the more powerful result to use). A common
 usage of this rule is with naturals, where `⊥ = 0`.


### PR DESCRIPTION
We rewrite the second paragraph, so that it first explains the general rule, and then mentions natural numbers as a common usage.