### PR TITLE
add BIRS workshop

### DIFF
--- a/data/events.yaml
+++ b/data/events.yaml
@@ -5,6 +5,13 @@
   end_date: August 16 2024
   type: conference
 
+- title: Formalization of cohomology theories
+  url: https://www.birs.ca/events/2023/5-day-workshops/23w5124
+  start_date: May 21 2023
+  end_date: May 26 2023
+  location: Banff, Alberta, Canada
+  type: workshop
+
 - title: Machine Assisted Proofs
   url: http://www.ipam.ucla.edu/programs/workshops/machine-assisted-proofs/
   location: IPAM. Los Angeles
@@ -32,13 +39,6 @@
   end_date: July 15 2022
   location: Providence, RI, USA
   type: tutorial
-
-- title: Formalization of cohomology theories
-  url: https://www.birs.ca/events/2023/5-day-workshops/23w5124
-  start_date: May 21 2022
-  end_date: May 26 2022
-  location: Banff, Alberta, Canada
-  type: workshop
 
 - title: LeaN in LyoN 
   url: https://www.univ-st-etienne.fr/lean-in-lyon.html

--- a/data/events.yaml
+++ b/data/events.yaml
@@ -33,6 +33,13 @@
   location: Providence, RI, USA
   type: tutorial
 
+- title: Formalization of cohomology theories
+  url: https://www.birs.ca/events/2023/5-day-workshops/23w5124
+  start_date: May 21 2022
+  end_date: May 26 2022
+  location: Banff, Alberta, Canada
+  type: workshop
+
 - title: LeaN in LyoN 
   url: https://www.univ-st-etienne.fr/lean-in-lyon.html
   start_date: May 10 2022


### PR DESCRIPTION
Adding the BIRS workshop on formalization for cohomology theories. Future website 
is https://www.birs.ca/events/2023/5-day-workshops/23w5124. 
