### PR TITLE
change main page wording

### DIFF
--- a/data/presentation.md
+++ b/data/presentation.md
@@ -9,11 +9,13 @@ Lean proof assistant. The library also contains definitions
 useful for programming. This project is very active, with many
 regular contributors and daily activity.
 
-The contents, design, and community organization of mathlib are
-described in the paper
-[The Lean mathematical library](https://arxiv.org/abs/1910.09336), which appeared
-at CPP 2020. You can get a bird's eye view of what is in the library by
-reading [the library overview](mathlib-overview.html).
+You can get a bird's-eye view of what is in the mathlib library by
+reading [the library overview](mathlib-overview.html), and read about
+recent additions on our [blog](blog.html).
+The design and community organization of mathlib are
+described in the 2020 article
+[The Lean mathematical library](https://arxiv.org/abs/1910.09336), although
+the library has grown by an order of magnitude since that article appeared. 
 You can also have a look at our [repository statistics](mathlib_stats.html)
-to see how it grows and who contributes to it.
+to see how the library grows and who contributes to it.
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -54,7 +54,6 @@
         Lean has very diverse and active community. It gathers mostly on
     a <a href="https://leanprover.zulipchat.com/">Zulip chat</a>
     and on <a href="https://github.com/leanprover-community/mathlib">GitHub</a>.
-    We also have a <a href="blog/">blog</a>.
     You can get involved and join the fun!
 		</p>
 		</div>


### PR DESCRIPTION
The current wording of the main page points readers to the overview and the CPP 2020 paper on mathlib for information on mathlib's contents.  The CPP paper is is now a bad source for such information (it describes a 140,000-line mathlib which is wrong by a factor of 7!).  I re-worded to point to the overview and blog for mathlib's contents, continuing to point to the CPP 2020 paper for "design and community organization."

I also dropped the phrase "CPP 2020", which will mean nothing to much of the target audience.  It would be good to instead add "published at CPP 2020" to the paper's own arxiv page; cc @robertylewis who is the arxiv owner of that paper.