### PR TITLE
Allow deeper nesting within undergrad.yml

### DIFF
--- a/templates/undergrad.html
+++ b/templates/undergrad.html
@@ -20,6 +20,17 @@
         docs/undergrad.yaml</a> in the mathlib repository.
       </p>
 
+  {% macro flat_child(item) -%}
+    {%- if item.children -%}
+      {{ item.title }}(
+      {%- for item in subarea.nonempty_children -%}
+        {{ flat_child(item) }}{% if not loop.last %}, {% endif %}
+      {%- endfor -%})
+    {%- else -%}
+      <a href="{{ item.decl }}">{{ item.title }}</a>
+    {%- endif -%}
+  {%- endmacro -%}
+
   {% for area in overviews %}
     {% if area.is_nonempty %}
     <h4>{{ area.title }}</h4>
@@ -27,7 +38,7 @@
         <p class="ml-4 mb-2">
         <b>{{ subarea.title }}</b>
         {% for item in subarea.nonempty_children %}
-          <a href="{{ item.decl }}">{{ item.title }}</a>{% if not loop.last %}, {% else %}.{% endif %}
+          {{ flat_child(item) }}{% if not loop.last %}, {% else %}.{% endif %}
         {% endfor %}
         </p>
       {% endfor %}

--- a/templates/undergrad_todo.html
+++ b/templates/undergrad_todo.html
@@ -29,6 +29,17 @@
       docs/undergrad.yaml</a> in the mathlib repository.
     </p>
 
+  {% macro flat_child(item) -%}
+    {%- if item.missing_children -%}
+      {{ item.title }}(
+      {%- for item in subarea.missing_children -%}
+        {{ flat_child(item) }}{% if not loop.last %}, {% endif %}
+      {%- endfor -%})
+    {%- else -%}
+      {% if item.url %}<a href="{{ item.url }}">{{ item.title }}</a>{% else %}{{ item.title }}{% endif %}
+    {%- endif -%}
+  {%- endmacro -%}
+  
   {% for area in overviews %}
     {% if area.has_missing_child %}
     <h4>{{ area.title }}</h4>
@@ -36,7 +47,7 @@
         <p class="ml-4 mb-2">
         <b>{{ subarea.title }}: </b>
         {% for item in subarea.missing_children %}
-	{% if item.url %}<a href="{{ item.url }}">{{ item.title }}</a>{% else %}{{ item.title }}{% endif %}{% if not loop.last %}, {% else %}.{% endif %}
+	{{ flat_child(item) }}{% if not loop.last %}, {% else %}.{% endif %}
         {% endfor %}
         </p>
       {% endfor %}


### PR DESCRIPTION
This displays further nested entries as `title (linked_entry, linked_entry, linked_entry)`