### PR TITLE
Update installation and Lean projects instructions

### DIFF
--- a/templates/install/debian.md
+++ b/templates/install/debian.md
@@ -1,23 +1,4 @@
-<div class="alert alert-info">
-<p>
-We are currently updating the Lean community website to describe working with Lean 4,
-but most of the information you will find here today still describes Lean 3.
-</p>
-<p>
-Pull requests updating this page for Lean 4 are very welcome.
-There is a link at the bottom of this page.
-</p>
-<p>
-Please visit <a href="https://leanprover.zulipchat.com">the leanprover zulip</a>
-and ask for whatever help you need during this transitional period!
-</p>
-<p>
-The website for Lean 3 has been <a href="https://leanprover-community.github.io/lean3/">archived</a>.
-If you need to link to Lean 3 specific resources please link there.
-</p>
-</div>
-
-# How to install Lean and mathlib on Debian/Ubuntu
+# How to install Lean 4 and mathlib on Debian/Ubuntu
 
 This document explains how to get started with Lean and mathlib if you
 are using a Linux distribution derived from Debian (Debian itself,
@@ -25,22 +6,17 @@ Ubuntu, LMDE,...).
 
 If you get stuck, please come to [the chat room](https://leanprover.zulipchat.com/) to ask for assistance.
 
-There is a [video walkthrough](https://www.youtube.com/watch?v=02ff4WrW0FU) of these instructions on YouTube.
-
-## Installing Lean and mathlib
-
 Here we will discuss the fast way, assuming a lot of trust from you. It
-will install Lean, with supporting tools `elan` and `leanpkg`,
-the supporting tool `leanproject` for Lean's mathematical
-library, as well as the code editor VS Code and its Lean plugin, and
-other dependencies you probably already have, like `curl`, `git`,
-`python3`, and `pip3`. If you don't like this method, there is a
+will install Lean, with supporting tools `elan` and `lake`, as well as the 
+code editor VS Code and its Lean plugin, and
+other dependencies you probably already have, like `curl` and `git`. 
+If you don't like this method, there is a
 [detailed webpage](debian_details.html) which will decompose the
 process into described stages, and won't ask for a blind `sudo`.
 
 The fast way is: open a terminal and type:
 ```bash
-wget -q https://raw.githubusercontent.com/leanprover-community/mathlib-tools/master/scripts/install_debian.sh && bash install_debian.sh ; rm -f install_debian.sh && source ~/.profile
+wget -q https://raw.githubusercontent.com/leanprover-community/mathlib4/master/scripts/install_debian.sh && bash install_debian.sh ; rm -f install_debian.sh && source ~/.profile
 ```
 
 ## Lean Projects

--- a/templates/install/debian_details.md
+++ b/templates/install/debian_details.md
@@ -1,36 +1,17 @@
-<div class="alert alert-info">
-<p>
-We are currently updating the Lean community website to describe working with Lean 4,
-but most of the information you will find here today still describes Lean 3.
-</p>
-<p>
-Pull requests updating this page for Lean 4 are very welcome.
-There is a link at the bottom of this page.
-</p>
-<p>
-Please visit <a href="https://leanprover.zulipchat.com">the leanprover zulip</a>
-and ask for whatever help you need during this transitional period!
-</p>
-<p>
-The website for Lean 3 has been <a href="https://leanprover-community.github.io/lean3/">archived</a>.
-If you need to link to Lean 3 specific resources please link there.
-</p>
-</div>
-
-# Controlled installation of Lean and mathlib on Debian/Ubuntu
+# Controlled installation of Lean 4 and mathlib on Debian/Ubuntu
 
 This document explains a more controlled installation procedure
-for Lean and mathlib on Linux distributions derived from Debian (Debian itself,
-Ubuntu, LMDE,...). There is a quicker way described in the main
+for Lean 4 and mathlib on Linux distributions derived from Debian (Debian
+itself, Ubuntu, LMDE,...). There is a quicker way described in the main
 [install page](debian.html) but it requires more trust.
 Of course you can get even more details about what is going on by
 reading the bash script that will be downloaded below:
 [elan_init](https://github.com/leanprover/elan/blob/master/elan-init.sh).
 
 * Lean itself doesn't depend on much infrastructure, but supporting tools
-  needed by most users require `git`, `curl`, and `python`. So the first step is:
+  needed by most users require `git` and `curl`. So the first step is:
   ```bash
-  sudo apt install git curl python3 python3-pip python3-venv
+  sudo apt install git curl
   ```
 
 * The next step installs a small tool called `elan` which will handle
@@ -41,30 +22,22 @@ reading the bash script that will be downloaded below:
   curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh
   ```
 
-* There are two editors you can use with Lean, VS Code and emacs. The
-  recommended choice is [Visual Studio Code](https://code.visualstudio.com/).
+* There are three editors you can use with Lean, VS Code, emacs and neovim. The
+  recommended choice is [Visual Studio Code](https://code.visualstudio.com/) which has
+  the most complete and well-tested support for Lean.
   ```bash
   wget -O code.deb https://go.microsoft.com/fwlink/?LinkID=760868
   sudo apt install ./code.deb
   rm code.deb
-  code --install-extension jroesch.lean
+  code --install-extension leanprover.lean4
   ```
 
   Now open VS Code, and verify Lean is working, for example by saving a file `test.lean` and entering `#eval 1+1`.
    A green line should appear underneath `#eval 1+1`, and hovering the mouse over it you should see `2`
    displayed.
 
-  The alternative is to use Emacs, and its [lean-mode](https://github.com/leanprover/lean-mode).
-
-* Then we install a small tool called `leanproject` that which will handle
-  updating mathlib according to the needs of your current project. We use
-  [pipx](https://pipxproject.github.io/pipx/) to perform the installation.
-  ```bash
-  python3 -m pip install --user pipx
-  python3 -m pipx ensurepath
-  source ~/.profile
-  pipx install mathlibtools
-  ```
+  Alternatively, you can use Emacs and its [lean4-mode](https://github.com/leanprover/lean4-mode) or
+  neovim and its [lean.nvim extension](https://github.com/Julian/lean.nvim).
 
 ## Lean Projects
 

--- a/templates/install/linux.md
+++ b/templates/install/linux.md
@@ -1,31 +1,11 @@
-<div class="alert alert-info">
-<p>
-We are currently updating the Lean community website to describe working with Lean 4,
-but most of the information you will find here today still describes Lean 3.
-</p>
-<p>
-Pull requests updating this page for Lean 4 are very welcome.
-There is a link at the bottom of this page.
-</p>
-<p>
-Please visit <a href="https://leanprover.zulipchat.com">the leanprover zulip</a>
-and ask for whatever help you need during this transitional period!
-</p>
-<p>
-The website for Lean 3 has been <a href="https://leanprover-community.github.io/lean3/">archived</a>.
-If you need to link to Lean 3 specific resources please link there.
-</p>
-</div>
-
-# Installing Lean and mathlib on Linux
+# Installing Lean 4 and mathlib on Linux
 
 This document explains how to get started with Lean and mathlib on a generic Linux distribution (there is a [specific page](debian.html) for Debian and derived distributions such as Ubuntu).
 
 All commands below should be typed inside a terminal.
 
 * Lean itself doesn't depend on much infrastructure, but supporting tools
-  needed by most users require `git`, `curl`, and `python3` (on Debian and
-  Ubuntu also `python3-pip` and `python3-venv`). So the first step is to get those.
+  needed by most users require `git` and `curl`. So the first step is to get those.
 
 * The next step installs a small tool called [`elan`](https://github.com/leanprover/elan) which will handle
   updating Lean according to the needs of your current project (hit Enter
@@ -36,30 +16,21 @@ All commands below should be typed inside a terminal.
   ```
 
 * You will also need a code editor that has a Lean plugin. The
-  recommended choice is [Visual Studio Code](https://code.visualstudio.com/).
-  The alternative is to use Emacs, and its [lean-mode](https://github.com/leanprover/lean-mode).
+  recommended choice is [Visual Studio Code](https://code.visualstudio.com/) which currently
+  has the best Lean support.
+  The alternatives are to use Emacs and its [lean-mode](https://github.com/leanprover/lean-mode)
+  or neovim and its  [lean.nvim extension](https://github.com/Julian/lean.nvim).
 
   1. Install [VS Code](https://code.visualstudio.com/).
   2. Launch VS Code.
   3. Click on the extension icon ![(image of icon)](img/new-extensions-icon.png)
      (or ![(image of icon)](img/extensions-icon.png) in older versions) in the side bar on the left edge of
      the screen (or press <kbd>Shift</kbd><kbd>Ctrl</kbd><kbd>X</kbd>) and search for `leanprover`.
-  4. Select the `lean` extension (unique name `jroesch.lean`). There is also a
-     `lean4` extension, but that one does not work with mathlib.
+  4. Select the `lean4` extension (unique name `leanprover.lean4`). 
   5. Click "install" (In old versions of VS Code, you might need to click "reload" afterwards)
   6. Verify Lean is working, for example by saving a file `test.lean` and entering `#eval 1+1`.
     A green line should appear underneath `#eval 1+1`, and hovering the mouse over it you should see `2`
     displayed.
-
-* Then we install a small tool called `leanproject` that which will handle
-  updating mathlib according to the needs of your current project. We use
-  [pipx](https://pipxproject.github.io/pipx/) to perform the installation.
-  ```bash
-  python3 -m pip install --user pipx
-  python3 -m pipx ensurepath
-  source ~/.profile
-  pipx install mathlibtools
-  ```
 
 ## Lean Projects
 

--- a/templates/install/macos.md
+++ b/templates/install/macos.md
@@ -1,32 +1,11 @@
-<div class="alert alert-info">
-<p>
-We are currently updating the Lean community website to describe working with Lean 4,
-but most of the information you will find here today still describes Lean 3.
-</p>
-<p>
-Pull requests updating this page for Lean 4 are very welcome.
-There is a link at the bottom of this page.
-</p>
-<p>
-Please visit <a href="https://leanprover.zulipchat.com">the leanprover zulip</a>
-and ask for whatever help you need during this transitional period!
-</p>
-<p>
-The website for Lean 3 has been <a href="https://leanprover-community.github.io/lean3/">archived</a>.
-If you need to link to Lean 3 specific resources please link there.
-</p>
-</div>
+# How to install Lean 4 and mathlib on MacOS
 
-# How to install Lean and mathlib on MacOS
-
-This document explains how to get started with Lean and mathlib if you
+This document explains how to get started with Lean 4 and mathlib if you
 are using MacOS.
 
 If you get stuck, please come to [the chat room](https://leanprover.zulipchat.com/) to ask for assistance.
 
-There is a [video walkthrough](https://www.youtube.com/watch?v=NOGWsCNm_FY) of these instructions on YouTube.
-
-## Installing Lean and mathlib
+## Installing Lean 4 and mathlib
 
 ### Intel Macs
 
@@ -40,7 +19,7 @@ process into described stages, and won't ask for a blind `sudo`.
 
 The fast way is: open a terminal and type:
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/leanprover-community/mathlib-tools/master/scripts/install_macos.sh)" && source ~/.profile
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/leanprover-community/mathlib4/master/scripts/install_macos.sh)" && source ~/.profile
 ```
 
 ### M1 Macs / Apple Silicon
@@ -69,7 +48,7 @@ elan toolchain install stable
 elan default stable
 ```
 
-5. Install Visual Studio Code and the Lean extension via `brew install --cask visual-studio-code && code --install-extension jroesch.lean` (both the x86 and ARM versions of `brew` should work).
+5. Install Visual Studio Code and the Lean extension via `brew install --cask visual-studio-code && code --install-extension leanprover.lean4` (both the x86 and ARM versions of `brew` should work).
 
 There is a [Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/M1.20macs)
 with some interim further details and advice. If you have trouble, feel free to ask for help.

--- a/templates/install/macos_details.md
+++ b/templates/install/macos_details.md
@@ -1,23 +1,4 @@
-<div class="alert alert-info">
-<p>
-We are currently updating the Lean community website to describe working with Lean 4,
-but most of the information you will find here today still describes Lean 3.
-</p>
-<p>
-Pull requests updating this page for Lean 4 are very welcome.
-There is a link at the bottom of this page.
-</p>
-<p>
-Please visit <a href="https://leanprover.zulipchat.com">the leanprover zulip</a>
-and ask for whatever help you need during this transitional period!
-</p>
-<p>
-The website for Lean 3 has been <a href="https://leanprover-community.github.io/lean3/">archived</a>.
-If you need to link to Lean 3 specific resources please link there.
-</p>
-</div>
-
-# Controlled installation of Lean and mathlib on MacOS
+# Controlled installation of Lean 4 and mathlib on MacOS
 
 This document explains a more controlled installation procedure for Lean and
 mathlib on MacOS. There is a quicker way described in the main
@@ -26,23 +7,19 @@ mathlib on MacOS. There is a quicker way described in the main
 If you get stuck, please come to [the chat room](https://leanprover.zulipchat.com/) to ask for
 assistance.
 
-We'll need to set up Lean, an editor that knows about Lean, and [`mathlib`](https://github.com/leanprover-community/mathlib/) (the standard library).
+We'll need to set up Lean, an editor that knows about Lean, and [`mathlib`](https://github.com/leanprover-community/mathlib4/) (the math library).
 
 Rather than installing Lean directly, we'll install a small program called [`elan`](https://github.com/leanprover/elan) which
 automatically provides the correct version of Lean on a per-project basis. This is recommended for
 all users.
-
-We'll also install [`mathlib-tools`](https://github.com/leanprover-community/mathlib-tools),
-which, amongst other things, let you download compiled binaries for `mathlib`.
 
 Installing `elan` and mathlib supporting tools
 ---
 
 1.  Install [Homebrew](https://brew.sh/) if you do not already have it installed.
 
-2.  Run `brew install elan-init mathlibtools` in a terminal window to
-    install `elan`, as well as the supporting toolset for working with
-    `mathlib`.
+2.  Run `brew install elan-init` in a terminal window to
+    install `elan`.
 
     Note that Homebrew also contains a formula named simply `lean`, but
     that it installs a fixed version of Lean, rather than one provisioned
@@ -57,16 +34,17 @@ Installing `elan` and mathlib supporting tools
 Installing and configuring an editor
 ---
 
-There are two editors you can use with Lean, VS Code and emacs.
-This document describes using VS Code (for emacs, look at https://github.com/leanprover/lean-mode).
+There are three editors you can use with Lean, VS Code emacs and neovim.
+This document describes using VS Code which currently has the best support for Lean.
+For emacs, look at https://github.com/leanprover/lean4-mode. 
+For neovim, look at https://github.com/Julian/lean.nvim)
 
 1. Install [VS Code](https://code.visualstudio.com/).
 2. Launch VS Code.
 3. Click on the extension icon ![(image of icon)](img/new-extensions-icon.png)
    (or ![(image of icon)](img/extensions-icon.png) in older versions) in the side bar on the left edge of
    the screen (or press <kbd>⇧ Shift</kbd><kbd>⌘ Command</kbd><kbd>X</kbd>) and search for `leanprover`.
-4. Select the `lean` extension (unique name `jroesch.lean`). There is also a
-   `lean4` extension, but that one does not work with mathlib.
+4. Select the `lean4` extension (unique name `leanprover.lean4`).
 5. Click "install" (In old versions of VS Code, you might need to click "reload" afterwards)
 6. Verify Lean is working, for example by saving a file `test.lean` and entering `#eval 1+1`.
    A green line should appear underneath `#eval 1+1`, and hovering the mouse over it you should see `2`
@@ -75,26 +53,3 @@ This document describes using VS Code (for emacs, look at https://github.com/lea
 ## Lean Projects
 
 You can now read instructions about creating and working on [Lean projects](project.html)
-
-Aside: Migrating From Older Installations
----
-
-Older versions of this installation guide recommended a different method
-of installation, involving manually installing `elan` directly from
-GitHub, procuring `pipx` and using that to install `mathlib-tools`
-(`leanproject`).
-
-If you have installed things this way, you can migrate to the newer
-installation mechanism by running:
-
-  ```sh
-  pipx uninstall mathlibtools && brew install mathlibtools
-  ```
-
-and
-
-  ```sh
-  elan self uninstall && brew install elan-init
-  ```
-
-for `mathlib-tools` and `elan` respectively.

--- a/templates/install/project.md
+++ b/templates/install/project.md
@@ -37,7 +37,7 @@ Open a terminal.
 
 * Run `cd mathematics_in_lean`
 
-* Run `lake exe cache get`
+* Run `lake exe cache get` (note: this command currently only works in projects which import `mathlib4` as a dependency)
 
 * Launch VS Code, either through your application menu or by typing
   `code .`. (MacOS users need to take a one-off
@@ -63,6 +63,7 @@ commands should be typed in a terminal.
   error message saying `lake` is an unknown command and
   you have not logged in since you installed Lean, then
   you may need to first type `source ~/.profile` or `source ~/.bash_profile`.
+The keyword `math` at the end of this command adds `mathlib4` to the dependencies of your project, so that you can use `import Mathlib` in your project files.
 
 * Go inside the `my_project` folder and type `lake update`, then `lake exe cache get` and then `mkdir MyProject`.
 

--- a/templates/install/project.md
+++ b/templates/install/project.md
@@ -59,7 +59,7 @@ We will now create a new project depending on mathlib. The following
 commands should be typed in a terminal.
 
 * Go to a folder where you want to create a project in a subfolder
-  `my_project`, and type `lake +leanprover/lean4:nightly-2023-02-04 new my_project math`. If you get an
+  `my_project`, and type `lake +leanprover/lean4:nightly-2023-02-04 new my_project math`. Do not worry about the date in the previous command, it ensures you will use a sufficiently recent version of `lake` but has no impact on the version of `lean` your project will use. If you get an
   error message saying `lake` is an unknown command and
   you have not logged in since you installed Lean, then
   you may need to first type `source ~/.profile` or `source ~/.bash_profile`.

--- a/templates/install/project.md
+++ b/templates/install/project.md
@@ -1,22 +1,3 @@
-<div class="alert alert-info">
-<p>
-We are currently updating the Lean community website to describe working with Lean 4,
-but most of the information you will find here today still describes Lean 3.
-</p>
-<p>
-Pull requests updating this page for Lean 4 are very welcome.
-There is a link at the bottom of this page.
-</p>
-<p>
-Please visit <a href="https://leanprover.zulipchat.com">the leanprover zulip</a>
-and ask for whatever help you need during this transitional period!
-</p>
-<p>
-The website for Lean 3 has been <a href="https://leanprover-community.github.io/lean3/">archived</a>.
-If you need to link to Lean 3 specific resources please link there.
-</p>
-</div>
-
 # Lean projects
 
 In general, if you just open a single `.lean` file in your text editor
@@ -26,27 +7,24 @@ Every non-trivial piece of Lean code needs to live inside a *Lean project*
 A "Lean project" is more than just a folder that you've named "My Lean stuff".
 Rather, it's a folder containing some very specific things:
 in particular, a *git repository* and a file
-`leanpkg.toml` that gathers information about dependencies of the
+`lakefile.lean` that gathers information about dependencies of the
 project, including for instance the version of Lean that should be used.
 
 If you're interested in contributing to mathlib you only need to set up
 a Lean project once, which you can use for all your contributions —
 you don't need to set up a new Lean project for each new contribution.
 
-Setting up and managing all this is done by a little python program called `leanproject`.
+Setting up and managing all this is done by a program called `lake` (this is
+a contraction of `lean` and `make`).
 This page describes the basic use of this tool, and should be sufficient
 for everyday use.
 If this is not enough for your purposes, you can read the
-full [leanproject documentation](../leanproject.html).
-If you are really curious, you can also read
-[how pieces fit together](../toolchain.html).
-
-There is a [video walkthrough](https://www.youtube.com/watch?v=y3GsHIe4wZ4) of these instructions on YouTube.
+full [lake documentation](https://github.com/leanprover/lake/blob/master/README.md).
 
 ## Working on an existing project
 
 Suppose you want to work on an existing project. As example, we will take
-[the tutorial project](https://github.com/leanprover-community/tutorials).
+[the Mathematics in Lean book](https://github.com/leanprover-community/mathematics_in_lean).
 Open a terminal.
 
 * If you have not logged in since you installed Lean and mathlib, then
@@ -55,21 +33,25 @@ Open a terminal.
 
 * Go the the directory where you would like this package to live.
 
-* Run `leanproject get tutorials`.
+* Run `git clone https://github.com/leanprover-community/mathematics_in_lean.git`.
+
+* Run `cd mathematics_in_lean`
+
+* Run `lake exe cache get`
 
 * Launch VS Code, either through your application menu or by typing
-  `code tutorials`. (MacOS users need to take a one-off
+  `code .`. (MacOS users need to take a one-off
   [extra step](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line)
    to be able to launch VS Code from the command line.)
 
 * If you launched VS Code from a menu, on the main screen, or in the File menu,
   click "Open folder" (just "Open" on a Mac), and choose the folder
-  `tutorials` (*not* one of its subfolders).
+  `mathematics_in_lean` (*not* one of its subfolders).
 
 * Using the file explorer on the left-hand side, explore everything you
-  want in `tutorials/src`.
-  See the [tutorials instructions](https://github.com/leanprover-community/tutorials/blob/master/README.md)
-  for advice about how to do the exercises in this project.
+  want in `MIL`.
+  See the [MIL instructions](https://github.com/leanprover-community/mathematics_in_lean/blob/master/README.md)
+  for advice about how to do the exercises in this book.
 
 ## Creating a Lean project
 
@@ -77,42 +59,48 @@ We will now create a new project depending on mathlib. The following
 commands should be typed in a terminal.
 
 * Go to a folder where you want to create a project in a subfolder
-  `my_project`, and type `leanproject new my_project`. If you get an
-  error message saying `leanproject` is an unknown command and
-  you have not logged in since you installed Lean and mathlib, then
+  `my_project`, and type `lake +leanprover/lean4:nightly-2023-02-04 new my_project math`. If you get an
+  error message saying `lake` is an unknown command and
+  you have not logged in since you installed Lean, then
   you may need to first type `source ~/.profile` or `source ~/.bash_profile`.
 
+* Go inside the `my_project` folder and type `lake update`, then `lake exe cache get` and then `mkdir MyProject`.
+
 * Launch VS Code, either through your application menu or by typing
-  `code my_project`.
+  `code .`.
 
 * If you launched VS Code through a menu: on the main screen, or in the
   File menu, click "Open folder" (on a Mac, just "Open"), and
   choose the folder `my_project` (*not* one of its subfolders).
 
 * Your Lean code should now be put inside files with extension `.lean`
-  living in `my_project/src/` or a subfolder thereof. In the file explorer
-  on the left-hand side of VS Code, you can right-click on `src`, choose
+  living in `my_project/MyProject/` or a subfolder thereof. In the file explorer
+  on the left-hand side of VS Code, you can right-click on `MyProject`, choose
   `New file`, and type a filename to create a file there.
 
 If you want to make sure everything is working, you can start by
-creating, say `my_project/src/test.lean` containing:
+creating, say `my_project/MyProject/test.lean` containing:
 ```lean
-import topology.basic
+import Mathlib.Topology.Basic
 
-#check topological_space
+#check TopologicalSpace
 ```
 When the cursor is on the last line, the right hand part of VS Code
-should display a "Lean Goal" area saying:
-`topological_space : Type u_1 → Type u_1`
+should display a "Lean Infoview" area saying:
+`TopologicalSpace.{u} (α : Type u) : Type u`.
 
-If, for some reason, you happen to lose the "Lean Goal" area, you
+Note that you can import you own files in the project. For instance if you created a
+file `my_project/MyProject/Definitions.lean`, you can start a new file
+`my_project/MyProject/Lemmas.lean` with `import MyProject.Definitions`.
+
+If, for some reason, you happen to lose the "Lean Infoview" area, you
 can get it back with <kbd>Ctrl</kbd>-<kbd>Shift</kbd>-<kbd>Enter</kbd>
 (<kbd>Cmd</kbd>-<kbd>Shift</kbd>-<kbd>Enter</kbd> on MacOS).
 Also, you can get the Lean documentation inside VS Code using
 <kbd>Ctrl</kbd>-<kbd>Shift</kbd>-<kbd>p</kbd>
 (<kbd>Cmd</kbd>-<kbd>Shift</kbd>-<kbd>p</kbd> on MacOS) and then,
 inside the text field that appears, type "lean doc" and hit <kbd>Enter</kbd>.
-Then click "Theorem Proving in Lean" and enjoy.
+Then click "Mathematics in Lean" or "Theorem Proving in Lean" and enjoy.
 
 ## Hosting your project on GitHub
 


### PR DESCRIPTION
Updating the install pages to Lean 4 using the new scripts from https://github.com/leanprover-community/mathlib4/pull/4965