### PR TITLE
add cs formalization conferences

### DIFF
--- a/data/events.yaml
+++ b/data/events.yaml
@@ -1,3 +1,31 @@
+- title: Interactive Theorem Proving 2023
+  url: https://mizar.uwb.edu.pl/ITP2023/
+  start_date: July 31 2023
+  end_date: August 4 2023
+  location: Bialystok, Poland
+  type: conference
+
+- title: Conference on Intelligent Computer Mathematics 2023
+  url: https://cicm-conference.org/2023/cicm.php
+  start_date: September 4 2023
+  end_date: September 8 2023
+  location: Cambridge, UK
+  type: conference
+
+- title: Certified Programs and Proofs 2023
+  url: https://popl23.sigplan.org/home/CPP-2023
+  start_date: January 16 2023
+  end_date: January 17 2023
+  location: Boston, MA, USA
+  type: conference
+
+- title: Certified Programs and Proofs 2024
+  url: https://popl24.sigplan.org/home/CPP-2024
+  start_date: January 15 2024
+  end_date: January 16 2024
+  location: London, UK
+  type: conference
+
 - title: Interactions of Proof Assistants and Mathematics
   url: https://itp-school-2023.github.io/
   start_date: September 18 2023


### PR DESCRIPTION
One reason we created the events page back in the day was to highlight CS "publication conferences" that weren't apparent to everyone. We've mised this summer cycle but this adds the past ones and CPP 2024, and let's add ITP and CICM 2024 when they're announced.