### PR TITLE
Super tiny fix dead link

### DIFF
--- a/data/presentation.md
+++ b/data/presentation.md
@@ -16,7 +16,7 @@ regular contributors and daily activity.
 
 You can get a bird's-eye view of what is in the mathlib library by
 reading [the library overview](mathlib-overview.html), and read about
-recent additions on our [blog](blog.html).
+recent additions on our [blog](blog).
 The design and community organization of mathlib are
 described in the 2020 article
 [The Lean mathematical library](https://arxiv.org/abs/1910.09336), although


### PR DESCRIPTION
Currently:

![image](https://github.com/leanprover-community/leanprover-community.github.io/assets/5236035/2eb6b272-c6a0-4620-a370-c52097f342ff)

gives:

![image](https://github.com/leanprover-community/leanprover-community.github.io/assets/5236035/0d621ea5-c2cc-488d-84aa-ee69682fdddf)

but if manually navigate to:

![image](https://github.com/leanprover-community/leanprover-community.github.io/assets/5236035/a2345f6b-34bb-4c91-af21-69130427341a)

it works:

![image](https://github.com/leanprover-community/leanprover-community.github.io/assets/5236035/7755d570-583c-40b1-9c88-acfb83a2c4dc)
