### PR TITLE
Corrected a link

### DIFF
--- a/data/menus.yaml
+++ b/data/menus.yaml
@@ -2,7 +2,7 @@
   items:
     - Zulip chat: https://leanprover.zulipchat.com/
     - GitHub: https://github.com/leanprover-community/mathlib
-    - Blog: blog
+    - Blog: https://leanprover-community.github.io/blog
     - Community information: meet.html
     - Teams: teams.html
     - Papers about Lean: papers.html

--- a/data/presentation.md
+++ b/data/presentation.md
@@ -3,7 +3,7 @@
 The [Lean theorem prover](https://leanprover.github.io)
 is a proof assistant developed principally by Leonardo de Moura at Microsoft Research.
 
-The current stable version of Lean is Lean 3, and this website is mostly about Lean 3. 
+The current stable version of Lean is Lean 3, and this website is mostly about Lean 3.
 But the community is currently switching to Lean 4.
 
 The Lean mathematical library, *mathlib*, is a community-driven effort
@@ -14,11 +14,11 @@ regular contributors and daily activity.
 
 You can get a bird's-eye view of what is in the mathlib library by
 reading [the library overview](mathlib-overview.html), and read about
-recent additions on our [blog](blog.html).
+recent additions on our [blog](/blog/).
 The design and community organization of mathlib are
 described in the 2020 article
 [The Lean mathematical library](https://arxiv.org/abs/1910.09336), although
-the library has grown by an order of magnitude since that article appeared. 
+the library has grown by an order of magnitude since that article appeared.
 You can also have a look at our [repository statistics](mathlib_stats.html)
 to see how the library grows and who contributes to it.
 

--- a/make_site.py
+++ b/make_site.py
@@ -485,7 +485,7 @@ def render_site(target: Path, base_url: str, reloader=False):
 
 if __name__ == '__main__':
     if '--local' in sys.argv:
-        base_url = f"file://{(Path(__file__).parent/'build').absolute()}/"
+        base_url = f"file://{(Path(__file__).parent/'build'/'lean3').absolute()}/"
     else:
-        base_url = 'https://leanprover-community.github.io/'
-    render_site(ROOT/'build', base_url, reloader='--reload' in sys.argv)
+        base_url = 'https://leanprover-community.github.io/lean3/'
+    render_site(ROOT/'build'/'lean3', base_url, reloader='--reload' in sys.argv)

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -46,6 +46,21 @@
 
 <div id="mainbox">
 
+  <div class="alert alert-info">
+    <p>
+    This webpage is about Lean 3, which is currently being deprecated,
+    while the community is migrating to Lean 4.
+    </p>
+    {% if name is defined %}
+    <p>
+    Jump to the
+    <a class="nav-link active" href="https://leanprover-community.github.io/{% if name.endswith('.md') %}{{ name[:-3] }}.html{% else %}{{ name }}{% endif %}">
+      corresponding page
+    </a>
+    on the main Lean 4 website.
+    {% endif %}
+  </div>
+
   <main>
 	  {% block content %}
     {% endblock %}

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -47,6 +47,7 @@
 <div id="mainbox">
 
   <main>
+    <div></div>
     <div class="alert alert-info">
       <p>
       This webpage is about Lean 3, which is currently being deprecated,
@@ -54,7 +55,11 @@
       </p>
       {% if name is defined %}
       <p>
-      Jump to the <a class="nav-link active" href="https://leanprover-community.github.io/{% if name.endswith('.md') %}{{ name[:-3] }}.html{% else %}{{ name }}{% endif %}">corresponding page</a> on the main Lean 4 website.
+      Jump to the
+      <a href="https://leanprover-community.github.io/{% if name.endswith('.md') %}{{ name[:-3] }}.html{% else %}{{ name }}{% endif %}">
+        corresponding page
+      </a>
+      on the main Lean 4 website.
       </p>
       {% endif %}
     </div>

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -46,23 +46,20 @@
 
 <div id="mainbox">
 
-  <div class="alert alert-info">
-    <p>
-    This webpage is about Lean 3, which is currently being deprecated,
-    while the community is migrating to Lean 4.
-    </p>
-    {% if name is defined %}
-    <p>
-    Jump to the
-    <a class="nav-link active" href="https://leanprover-community.github.io/{% if name.endswith('.md') %}{{ name[:-3] }}.html{% else %}{{ name }}{% endif %}">
-      corresponding page
-    </a>
-    on the main Lean 4 website.
-    {% endif %}
-  </div>
-
   <main>
-	  {% block content %}
+    <div class="alert alert-info">
+      <p>
+      This webpage is about Lean 3, which is currently being deprecated,
+      while the community is migrating to Lean 4.
+      </p>
+      {% if name is defined %}
+      <p>
+      Jump to the <a class="nav-link active" href="https://leanprover-community.github.io/{% if name.endswith('.md') %}{{ name[:-3] }}.html{% else %}{{ name }}{% endif %}">corresponding page</a> on the main Lean 4 website.
+      </p>
+      {% endif %}
+    </div>
+
+    {% block content %}
     {% endblock %}
   </main>
 

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -47,7 +47,6 @@
 <div id="mainbox">
 
   <main>
-    <div></div>
     <div class="alert alert-info">
       <p>
       This webpage is about Lean 3, which is currently being deprecated,

--- a/templates/install/macos.md
+++ b/templates/install/macos.md
@@ -42,7 +42,7 @@ The following instructions are adapted from [Fedor Pavutnitskiy](https://leanpro
 
 3. Install a second installation of Homebrew for `x86` with `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`. It will automatically install itself into a second location (`/usr/local`, rather than `/opt/`).
 
-4. Follow the same steps described in [Controlled Installation for macOS]([https://leanprover-community.github.io/install/macos_details.html](https://leanprover-community.github.io/lean3/install/macos_details.html)) using the `brew` you just installed:
+4. Follow the same steps described in [Controlled Installation for macOS](https://leanprover-community.github.io/lean3/install/macos_details.html) using the `brew` you just installed:
 
 ```
 /usr/local/bin/brew install elan-init mathlibtools

--- a/templates/install/macos.md
+++ b/templates/install/macos.md
@@ -42,7 +42,7 @@ The following instructions are adapted from [Fedor Pavutnitskiy](https://leanpro
 
 3. Install a second installation of Homebrew for `x86` with `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`. It will automatically install itself into a second location (`/usr/local`, rather than `/opt/`).
 
-4. Follow the same steps described in [Controlled Installation for macOS](https://leanprover-community.github.io/install/macos_details.html) using the `brew` you just installed:
+4. Follow the same steps described in [Controlled Installation for macOS]([https://leanprover-community.github.io/install/macos_details.html](https://leanprover-community.github.io/lean3/install/macos_details.html)) using the `brew` you just installed:
 
 ```
 /usr/local/bin/brew install elan-init mathlibtools


### PR DESCRIPTION
The only relevant part of this PR is the file templates/install/macos.md, where I corrected the link, which does not work because of the markdown syntax.

The issue is that the link in question does not work when one clicks on it on the following webpage:

https://leanprover-community.github.io/lean3/install/macos.html

