### PR TITLE
update the contribution page to Lean 4 and add commit conventions

### DIFF
--- a/data/menus.yaml
+++ b/data/menus.yaml
@@ -53,6 +53,7 @@
     - Naming conventions: contribute/naming.html
     - Code style guideline: contribute/style.html
     - Documentation style: contribute/doc.html
+    - Commit conventions: contribute/commit.html
     - CI for 3rd party projects: ci.html
     - Contribution statistics: mathlib_stats.html
 

--- a/templates/contribute/commit.md
+++ b/templates/contribute/commit.md
@@ -1,0 +1,95 @@
+# Pull request title and description conventions
+
+We are using the following convention for writing pull request titles and descriptions.
+
+## Format
+
+Note: "Title:" and "Description:" do not actually appear
+
+```markdown
+  Title:
+  <type>(<optional-scope>): <subject>
+
+  Description:
+  <body>
+  <NEWLINE>
+  <footer>
+  <NEWLINE>
+  <dependencies>
+```
+
+`<type>` is:
+
+ - feat (feature)
+ - fix (bug fix)
+ - doc (documentation)
+ - style (formatting, missing semicolons, ...)
+ - refactor
+ - test (when adding missing tests)
+ - chore (maintain)
+ - perf (performance improvement, optimization, ...)
+
+`<optional-scope>` is a name of module or a directory which contains changed modules.
+This is not necessary to include, but may be useful if the `<subject>` is insufficient.
+The `Mathlib` directory prefix is always omitted.
+For instance, it could be
+
+- Data/Nat/Basic
+- Algebra/Group/Defs
+- Topology/Constructions
+
+`<subject>` has the following constraints:
+
+- use imperative, present tense: "change" not "changed" nor "changes"
+- do not capitalize the first letter
+- no dot(.) at the end
+
+`<body>` has the following constraints:
+
+- just as in ``<subject>``, use imperative, present tense
+- include motivation for the change and contrast with previous
+  behavior
+
+`<footer>` is optional and may contain two items:
+
+- Breaking changes: All breaking changes have to be mentioned in
+  footer with the description of the change, justification and
+  migration notes
+- Referencing issues: Closed bugs should be listed on a separate line
+  in the footer prefixed with "Closes" keyword like this: Closes #123, #456
+
+`<dependencies>` if this PR depends on others, they should be listed 
+in checkbox format, i.e., `- [ ] depends on: #XXXX`
+
+## Examples
+
+An example where `<scope>` is not necessary might be:
+
+```markdown
+feat: have library search use the whole range for replacement
+
+previously `apply? using h` would replace to `refine blah using h` rather than `refine blah`.
+
+This also changes the diagnostic message to be on the whole syntax `apply? using h` rather than just the `apply?` bit, which seems fine to me.
+```
+
+And an example where including `<scope>` does add value:
+
+```markdown
+docs(CategoryTheory/EssentialImage): typo and punctuation
+
+Fix a typo, add two periods.
+```
+
+an example with dependent PRs:
+
+```markdown
+feat: The norm on `Unitization` is a C⋆-norm
+
+This shows that C⋆-algebras are always `RegularNormedAlgebra`s, so that their `Unitization` is equipped with a norm. Moreover, we show this norm is a C⋆-norm.
+
+- [ ] depends on: #5330
+- [ ] depends on: #5741
+- [ ] depends on: #5742 
+- [ ] depends on: #5743 
+```

--- a/templates/contribute/index.md
+++ b/templates/contribute/index.md
@@ -71,7 +71,7 @@ It's also okay to let our central CI servers do this for you by pushing your cha
   (There will be a green tick on the line describing the most recent commit if everything works,
   otherwise a yellow circle if CI is still working, or a red cross if something went wrong.
   Click on the red cross to see details.)
-  You can also check CI status on the command line by installing `hub` and running `hub ci-status`.
+  You can also check CI status on the command line by installing [`hub`](https://hub.github.com/) and running `hub ci-status`.
 * After CI finishes, you can run `lake exe cache get` to download compiled oleans.
 
 

--- a/templates/contribute/index.md
+++ b/templates/contribute/index.md
@@ -1,22 +1,3 @@
-<div class="alert alert-info">
-<p>
-We are currently updating the Lean community website to describe working with Lean 4,
-but most of the information you will find here today still describes Lean 3.
-</p>
-<p>
-Pull requests updating this page for Lean 4 are very welcome.
-There is a link at the bottom of this page.
-</p>
-<p>
-Please visit <a href="https://leanprover.zulipchat.com">the leanprover zulip</a>
-and ask for whatever help you need during this transitional period!
-</p>
-<p>
-The website for Lean 3 has been <a href="https://leanprover-community.github.io/lean3/">archived</a>.
-If you need to link to Lean 3 specific resources please link there.
-</p>
-</div>
-
 # How to contribute to mathlib
 
 Here are some tips and tricks
@@ -51,36 +32,30 @@ rather than from your own fork, as CI works better this way.)
 
 Typical workflow:
 * To get started, you'll need a local copy of mathlib.
-* At https://github.com/leanprover-community/mathlib, click "Fork" in the top right, to make your own fork of the repository.
-  Your fork is at https://github.com/USER/mathlib.
-  Alternatively, if you've asked for write access you can just use https://github.com/leanprover-community/mathlib.
+* If you've asked for write access (recommended above), you can just use https://github.com/leanprover-community/mathlib4.
+  Otherwise, you'll need to go to https://github.com/leanprover-community/mathlib4 and click "Fork" in the top right,
+  to make your own fork of the repository.
+  Your fork is at https://github.com/USER/mathlib4.
 * Now make a local clone of the repository.
   ```
-  git clone https://github.com/USER/mathlib.git
-  cd mathlib
+  git clone https://github.com/leanprover-community/mathlib4.git
+  cd mathlib4
   ```
 * The steps above only need to be done once (not once for each contribution).
 * Now, each time you want to work on a new change to mathlib, create a new branch:
   ```
-  git checkout -b my_new_branch   # This creates a new branch
+  git switch -c my_new_branch   # This creates a new branch and switches to it
   ```
-  It's also fine to simply clone https://github.com/leanprover-community/mathlib.git,
-  but you won't be able to push changes unless you've asked for permission.
-  An alternative at this step is to use `leanproject`.
-  The command
-  ```
-  leanproject get -b mathlib:my_new_branch
-  ```
-  has the same effect as the `git clone` and `git checkout -b` commands described above,
-  except that it will clone into the directory `mathlib_my_new_branch`.
+  If you've asked for write access you can push your new branch to mathlib which
+  comes with some advantages (see below).
 * Sometimes you may not want to create a new branch, but instead work on a branch
   that someone else created, or you created from a different computer.
-  In that case you need to use `git checkout their_new_branch` (note there is no `-b` here).
+  In that case you need to use `git switch their_new_branch` (note there is no `-c` here).
 * Make local changes, e.g. using Visual Studio Code using the Lean extension.
-* Commit your changes using `git commit -a`.
+* Commit your changes using `git commit -a` (or via the VS Code interface).
 * If you'd like to compile everthing locally to check you didn't break anything, run
-`leanproject build`. This may take a long time if you modified files low down in the import hierarchy.
-It's also okay to let our central CI servers do this for you.
+`lake build`. This may take a long time if you modified files low down in the import hierarchy.
+It's also okay to let our central CI servers do this for you by pushing your changes.
 * In order to push your changes back to the repository on github, use
   ```
   git push
@@ -97,8 +72,7 @@ It's also okay to let our central CI servers do this for you.
   otherwise a yellow circle if CI is still working, or a red cross if something went wrong.
   Click on the red cross to see details.)
   You can also check CI status on the command line by installing `hub` and running `hub ci-status`.
-* After CI finishes, you can run `leanproject get-cache` to download compiled oleans.
-  See [Caching compilation](#caching-compilation) for commands to automatically call `leanproject get-cache`.
+* After CI finishes, you can run `lake exe cache get` to download compiled oleans.
 
 
 ## Making a Pull Request (PR)
@@ -110,10 +84,11 @@ please come to https://leanprover.zulipchat.com/, introduce yourself, and ask fo
 
 * Push your changes to a branch on the main repository, if they weren't already there.
 
-* If you've made a lot of changes/additions, try to make many PRs containing small, self-contained pieces. This helps you get feedback as you go along, and it is much easier to review. This is especially important for new contributors.
+* If you've made a lot of changes/additions, try to make many PRs containing small, self-contained pieces; in general, the smaller the better!
+  This helps you get feedback as you go along, and it is much easier to review.
+  This is especially important for new contributors as it prevents wasted effort.
 
-* The title of the PR should follow our [commit conventions](https://github.com/leanprover-community/lean/blob/master/doc/commit_convention.md).
-
+* The title and description of the PR should follow our [commit conventions](commit.html).
 
 ## Lifecycle of a PR
 
@@ -126,7 +101,7 @@ Click on the "labels" header to add or remove labels from the current project.
 The most important labels are "awaiting-review" and "awaiting-author". If your PR builds (has a green checkmark) and you label your PR with **"awaiting-review"**, someone will probably "review" it within a few days (depending on the size of the PR; smaller PRs will get quicker responses). The reviewer will probably leave comments and change the label to **"awaiting-author"**. You should address each comment, clicking the "resolve conversation" button once the problem is resolved. Ideally each problem is resolved with a new commit, but there is no hard rule here. Once all requested changes are implemented, you should change the label back to "awaiting-review" to start the process over again.
 
 After some iteration, a reviewer will "approve" the PR and the "ready-to-merge" label will be automatically applied to the PR. A bot called `bors` will take it from here. (See [here](https://github.com/leanprover-community/mathlib/blob/master/docs/contribute/bors.md) for more detail about bors.)
-After responding appropriately to bors (if necessary), the PR will get added to the ["merge queue"](https://app.bors.tech/repositories/24316). The merge queue gets cleared automatically, but this takes some finite amount of time as it requires building branches of mathlib.
+After responding appropriately to bors (if necessary), the PR will get added to the ["merge queue"](https://app.bors.tech/repositories/37904). The merge queue gets cleared automatically, but this takes some finite amount of time as it requires building branches of mathlib.
 
 Here are some other frequently-used labels:
 
@@ -147,18 +122,3 @@ whether to proceed at all.
 ### Dealing with merge conflicts
 
 Due to the fact that multiple people work on mathlib in parallel, someone might have introduced a change on `master` that conflicts with a change that you're proposing on your PR. If it happens with your PR, check [this GitHub tutorial](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-on-github) on how to resolve merge conflicts by using their online tool.
-
-## Caching compilation
-
-In the `mathlib` git repository, you can run the following in a terminal:
-
-```sh
-sudo pip3 install mathlibtools
-leanproject hooks
-```
-
-This will install the `leanproject` tool.  The call to `leanproject hooks`
-sets up git hooks that will call cache the olean files when making a commit
-and fetching the olean files when checking out a branch.
-See the [mathlib-tools documentation](https://github.com/leanprover-community/mathlib-tools/blob/master/README.md)
-for more information.


### PR DESCRIPTION
This does two things:

1. adds a page addressing the commit conventions (i.e., PR title and description conventions) for mathlib, as the one we used to link to was in the Lean (not Lean 4!) repository. That document was copied, and then edited it slightly to reflect mathlib better, including the optional `(<scope>)` listing the files changed.
2. updates the contribution page to Lean 4, including a link to the new commit conventions page.

