### PR TITLE
Correct yaml of event name

### DIFF
--- a/data/events.yaml
+++ b/data/events.yaml
@@ -1,4 +1,4 @@
-- title: Computer-verified proofs: 48 hours in Rome
+- title: "Computer-verified proofs: 48 hours in Rome"
   location: Rome, Italy
   url: https://www.mat.uniroma2.it/butterley/formalisation/
   start_date: January 24 2024


### PR DESCRIPTION
Event name contained a colon and I forgot to add quotes. Oops!

Mends the build failure see here [https://github.com/leanprover-community/leanprover-community.github.io/actions/runs/6287865482]

"yaml.scanner.ScannerError: mapping values are not allowed here in "data/events.yaml", line 1, column 34"