### PR TITLE
add comment about not making a new folder

### DIFF
--- a/templates/install/project.md
+++ b/templates/install/project.md
@@ -31,7 +31,7 @@ Open a terminal.
   you may need to first type `source ~/.profile` or
   `source ~/.bash_profile` depending on your OS.
 
-* Go the the directory where you would like this package to live.
+* Go the the directory where you would like this package to live. You do not need to create a new folder yourself, the next command will create a `mathematics_in_lean` subfolder for you.
 
 * Run `git clone https://github.com/leanprover-community/mathematics_in_lean.git`.
 


### PR DESCRIPTION
A very common mistake of new users is that they create a project folder themselves before cloning the repository. This often causes confusion in later steps (running `lake exe cache get` in the wrong directory, or opening the wrong directory in VSCode). I've seen new users do this on 3 different occasions now, and they got stuck at a later step.