### PR TITLE
remove theory docs from side menu

### DIFF
--- a/data/menus.yaml
+++ b/data/menus.yaml
@@ -39,14 +39,6 @@
     - Undergraduate maths: undergrad.html
     - Wiedijk's 100 theorems: 100.html
 
-- title: Theory docs
-  items:
-    - Category theory: theories/category_theory.html
-    - Linear algebra: theories/linear_algebra.html
-    - Natural numbers: theories/naturals.html
-    - Sets and set-like objects: theories/sets.html
-    - Topology: theories/topology.html
-
 - title: Contributing
   items:
     - Pull request lifecycle: contribute/index.html


### PR DESCRIPTION
Unlike the metaprogramming tutorial, I'm not totally sure these should go. Ideally they'd be updated. But not only are they about mathlib3, they're also out of date.