### PR TITLE
fix edit instructions for undergrad templates

### DIFF
--- a/templates/undergrad.html
+++ b/templates/undergrad.html
@@ -14,10 +14,14 @@
     <a href="undergrad_todo.html">not yet in mathlib</a>.
     </p>
 
-    <p>To update this list, please submit a PR modifying
-      <a href="https://github.com/leanprover-community/mathlib4/edit/master/docs/undergrad.yaml">
-        docs/undergrad.yaml</a> in the mathlib4 repository.
-      </p>
+    <p>To update this list, please take a look at the
+    <a href="https://github.com/leanprover-community/leanprover-community.github.io/blob/lean4/README.md">README</a>
+    regarding the contribution instructions and submit a PR modifying
+    <a href="https://github.com/leanprover-community/leanprover-community.github.io/blob/lean4/templates/undergrad.html">
+    templates/undergrad.html</a> in the
+    <a href="https://github.com/leanprover-community/leanprover-community.github.io">leanprover-community.github.io</a>
+    repository.
+  </p>
 
   {% macro flat_child(item) -%}
     {%- if item.children -%}

--- a/templates/undergrad_todo.html
+++ b/templates/undergrad_todo.html
@@ -23,9 +23,14 @@
     about this idea on <a href="https://leanprover.zulipchat.com/">Zulip</a>.
     </p>
 
-    <p>To update this list, please submit a PR modifying
-    <a href="https://github.com/leanprover-community/mathlib4/edit/master/docs/undergrad.yaml">
-      docs/undergrad.yaml</a> in the mathlib repository.
+    <p>To update this list, please take a look at the
+    <a href="https://github.com/leanprover-community/leanprover-community.github.io/blob/lean4/README.md">README</a>
+    regarding the contribution instructions and submit a PR modifying
+  <a
+    href="https://github.com/leanprover-community/leanprover-community.github.io/blob/lean4/templates/undergrad_todo.html">
+    templates/undergrad_todo.html</a> in the
+    <a href="https://github.com/leanprover-community/leanprover-community.github.io">leanprover-community.github.io</a>
+    repository.
     </p>
 
   {% macro flat_child(item) -%}


### PR DESCRIPTION
The "modifying" links on both https://leanprover-community.github.io/undergrad.html and https://leanprover-community.github.io/undergrad_todo.html point to https://github.com/leanprover-community/mathlib4/edit/master/docs/undergrad.yaml which I believe is incorrect.  Changed to point to `templates/undergrad.html` and `templates/undergrad_todo.html` in this repository.