### PR TITLE
Update index.md URLs at end of sentence followed by period are not rendered correctly.

### DIFF
--- a/templates/contribute/index.md
+++ b/templates/contribute/index.md
@@ -32,7 +32,7 @@ rather than from your own fork, as CI works better this way.)
 
 Typical workflow:
 * To get started, you'll need a local copy of mathlib.
-* If you've asked for write access (recommended above), you can just use [https://github.com/leanprover-community/mathlib4](https://github.com/leanprover-community/mathlib4).
+* If you've asked for write access (recommended above), you can just use <https://github.com/leanprover-community/mathlib4>.
   Otherwise, you'll need to go to https://github.com/leanprover-community/mathlib4 and click "Fork" in the top right,
   to make your own fork of the repository.
   Your fork is at [https://github.com/USER/mathlib4](https://github.com/USER/mathlib4).

--- a/templates/contribute/index.md
+++ b/templates/contribute/index.md
@@ -32,10 +32,10 @@ rather than from your own fork, as CI works better this way.)
 
 Typical workflow:
 * To get started, you'll need a local copy of mathlib.
-* If you've asked for write access (recommended above), you can just use https://github.com/leanprover-community/mathlib4.
+* If you've asked for write access (recommended above), you can just use [https://github.com/leanprover-community/mathlib4](https://github.com/leanprover-community/mathlib4).
   Otherwise, you'll need to go to https://github.com/leanprover-community/mathlib4 and click "Fork" in the top right,
   to make your own fork of the repository.
-  Your fork is at https://github.com/USER/mathlib4.
+  Your fork is at [https://github.com/USER/mathlib4](https://github.com/USER/mathlib4).
 * Now make a local clone of the repository.
   ```
   git clone https://github.com/leanprover-community/mathlib4.git


### PR DESCRIPTION
A URL at the end of a sentence following by a period is rendered with the period added to the URL, creating a broken link.