### PR TITLE
Make sure that lean.bib is always normalized

### DIFF
--- a/.github/workflows/bibtool.yml
+++ b/.github/workflows/bibtool.yml
@@ -1,0 +1,33 @@
+name: check bib
+
+on:
+  pull_request:
+    paths:
+      - lean.bib
+
+jobs:
+  build:
+    name: Run bibtool
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: install bibtool
+        run: |
+          sudo apt-get update --fix-missing
+          sudo apt-get install -y bibtool
+
+      - name: produce normalized file
+        run: |
+          bibtool --preserve.key.case=on \
+                  --preserve.keys=on \
+                  --pass.comments=on \
+                  --print.use.tab=off \
+                  -s -i lean.bib -o lean2.bib
+      - name: check diff
+        run: |
+          diff lean.bib lean2.bib || {
+            echo "::error::lean.bib is not normalized."
+            echo "::error::run 'bibtool --preserve.key.case=on --preserve.keys=on --pass.comments=on --print.use.tab=off -s -i lean.bib -o lean.bib' to fix the issue."
+            exit 1
+          }

--- a/lean.bib
+++ b/lean.bib
@@ -1,4 +1,6 @@
 
+# To normalize:
+# bibtool --preserve.key.case=on --preserve.keys=on --pass.comments=on --print.use.tab=off -s -i lean.bib -o lean.bib
 @InProceedings{   AGLST23,
   author        = {Avigad, Jeremy and Goldberg, Lior and Levit, David and
                   Seginer, Yoav and Titelman, Alon},
@@ -47,8 +49,6 @@
   tags          = {formalization, lean3}
 }
 
-# To normalize:
-# bibtool --preserve.key.case=on --preserve.keys=on --pass.comments=on --print.use.tab=off -s -i lean.bib -o lean.bib
 @Book{            Avig14,
   author        = "Avigad, Jeremy and {de Moura}, Leonardo and Kong, Soonho",
   title         = {{Theorem Proving in Lean}},


### PR DESCRIPTION
This PR adds a GitHub workflow that checks that `lean.bib` is normalized. 

The PR also brings the normalization instruction to the top. Unfortunately, `bibtool` will associate the instruction as a comment for the first bib entry, so a newer entry that precedes `AGLST23` (e.g., `AAA`) will still displace the instruction, and will require a manual fix again. However, this hopefully will be rare.