### PR TITLE
Fix indentation of an example in the style guide

### DIFF
--- a/templates/contribute/style.md
+++ b/templates/contribute/style.md
@@ -223,18 +223,18 @@ example:
 import Mathlib.Data.Nat.Basic
 
 theorem Nat.add_right_inj {n m k : Nat} : n + m = n + k → m = k :=
-Nat.recOn n
-  (fun H : 0 + m = 0 + k ↦ calc
-    m = 0 + m := Eq.symm (zero_add m)
-    _ = 0 + k := H
-    _ = k     := zero_add _)
-  (fun (n : Nat) (IH : n + m = n + k → m = k) (H : succ n + m = succ n + k) ↦
-    have H2 : succ (n + m) = succ (n + k) := calc
-      succ (n + m) = succ n + m   := Eq.symm (succ_add n m)
-      _            = succ n + k   := H
-      _            = succ (n + k) := succ_add n k
-    have H3 : n + m = n + k := succ.inj H2
-    IH H3)
+  Nat.recOn n
+    (fun H : 0 + m = 0 + k ↦ calc
+      m = 0 + m := Eq.symm (zero_add m)
+      _ = 0 + k := H
+      _ = k     := zero_add _)
+    (fun (n : Nat) (IH : n + m = n + k → m = k) (H : succ n + m = succ n + k) ↦
+      have H2 : succ (n + m) = succ (n + k) := calc
+        succ (n + m) = succ n + m   := Eq.symm (succ_add n m)
+        _            = succ n + k   := H
+        _            = succ (n + k) := succ_add n k
+      have H3 : n + m = n + k := succ.inj H2
+      IH H3)
 ```
 
 In a class or structure definition, fields are indented 2 spaces, and moreover


### PR DESCRIPTION
The entire body should be indented by two spaces, which means two more spaces than currently.

Zulip: https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Is.20the.20indentation.20level.20wrong.20in.20the.20style.20guide.3F