### PR TITLE
add David Renshaw as a mathlib reviewer

### DIFF
--- a/data/teams.yaml
+++ b/data/teams.yaml
@@ -82,6 +82,7 @@
     - Kyle Miller
     - Scott Morrison
     - Oliver Nash
+    - David Renshaw
     - Adam Topaz
     - Eric Wieser
     - Alex J. Best


### PR DESCRIPTION
I'm submitting this as prompted by @jcommelin on the "mathlib reviewers" zulip stream.
I added myself within the alphabetized first part of the list.