### PR TITLE
Add Michael Stoll to reviewers in teams.yaml, sort list

### DIFF
--- a/data/teams.yaml
+++ b/data/teams.yaml
@@ -59,14 +59,22 @@
   short_description: "The mathlib reviewer team helps the mathlib maintainers with the daily reviewing of PRs to mathlib. This team consists of experienced community members that have displayed quality in their contributions and reviews."
   description: "The mathlib reviewer team helps the mathlib maintainers with the daily reviewing of PRs to mathlib. This team consists of experienced community members that have displayed quality in their contributions and reviews. During the review process of a PR, they leave comments and feedback. Once they deem a PR ready for merging, they place the PR on a queue for a final review and merge instruction by the mathlib maintainers."
   members:
+    - Aaron Anderson
     - Anne Baanen
     - Matthew Robert Ballard
     - Reid Barton
+    - Alex J. Best
+    - Eric Rodriguez Boidi
     - Riccardo Brasca
+    - Thomas Browning
+    - Kevin Buzzard
     - Mario Carneiro
     - Bryan Gin-ge Chen
     - Johan Commelin
+    - Anatole Dedecker
     - Rémy Degenne
+    - Yaël Dillies
+    - Moritz Doll
     - Floris van Doorn
     - Frédéric Dupuis
     - Gabriel Ebner
@@ -76,30 +84,23 @@
     - Chris Hughes
     - Yury G. Kudryashov
     - Robert Y. Lewis
+    - Jireh Loreaux
     - Heather Macbeth
     - Patrick Massot
     - Bhavik Mehta
     - Kyle Miller
     - Scott Morrison
+    - Joseph Myers
     - Oliver Nash
     - David Renshaw
+    - Joël Riou
+    . Michael Stoll
+    - Damiano Testa
     - Adam Topaz
     - Eric Wieser
-    - Alex J. Best
     - Junyan Xu
-    - Jireh Loreaux
-    - Joseph Myers
-    - Thomas Browning
-    - Yaël Dillies
-    - Moritz Doll
     - Andrew Yang
-    - Joël Riou
-    - Anatole Dedecker
     - Kexing Ying
-    - Aaron Anderson
-    - Kevin Buzzard
-    - Eric Rodriguez Boidi
-    - Damiano Testa
   use_biography: False
   url: reviewers
 - name: Continuous integration


### PR DESCRIPTION
Following a request by @kbuzzard, I have taken the opportunity to sort the list of reviewers alphabetically by last name.