### PR TITLE
naming convention: recommend against ball and bex in mathlib

### DIFF
--- a/templates/contribute/naming.md
+++ b/templates/contribute/naming.md
@@ -81,6 +81,8 @@ When translating the statements of theorems into words, the following dictionary
 | `≠`    | `\ne`    | `ne`                      |                                                                     |
 | `∘`    | `\o`     | `comp`                    |                                                                     |
 
+`ball` and `bex` are still used in Lean core, but should not be used in mathlib.
+
 #### Set
 
 | symbol                      | shortcut    | name                 | notes                                         |


### PR DESCRIPTION
Per the reasoning in [mathlib4#10816](https://github.com/leanprover-community/mathlib4/pull/10816): these are confusing to newcomers, hence we try to avoid them.

They are still used somewhat in core, and in Mathlib/Logic/Basic - which is why I worded this relatively softly.