### PR TITLE
style guide: mention a space between tactic name and arguments

### DIFF
--- a/templates/contribute/style.md
+++ b/templates/contribute/style.md
@@ -505,6 +505,7 @@ example {x y : ℝ} (hxy : x ≤ y) (h : ∀ ε > 0, y - ε ≤ x) : x = y :=
 
 When using the tactics `rw` or `simp` there should be a space after the left arrow  `←`.
 For instance `rw [← add_comm a b]` or `simp [← and_or_left]`.
+(There should also be a space between the tactic name and its arguments, as in `rw [h]`.)
 This rule applies the `do` notation as well: `do return (← f) + (← g)`
 
 ### Normal forms


### PR DESCRIPTION
As [discussed on zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Style.3A.20spacing.20between.20tactic.20name.20and.20arguments).