### PR TITLE
feat: changes to the learn page

### DIFF
--- a/templates/learn.md
+++ b/templates/learn.md
@@ -4,13 +4,13 @@ There are many ways to start learning Lean, depending on your background and
 taste. They are all fun and rewarding, but also difficult and
 occasionally frustrating. Proof assistants are still difficult to use,
 and you cannot expect to become proficient after one afternoon of
-learning. Note that all resources listed on that page are about Lean 4. 
+learning. Note that all resources listed on that page are about Lean 4.
 There is no point learning Lean 3 at this stage.
 
 ## Hands-on approaches
 
 * Whatever your background, if you want to dive right away, you can play the
-  [Natural Number Game](https://adam.math.hhu.de/#/g/hhu-adam/NNG4). 
+  [Natural Number Game](https://adam.math.hhu.de/#/g/hhu-adam/NNG4).
   This is an online interactive tutorial to Lean
   focused on proving properties of the elementary operations on natural numbers.
 
@@ -24,7 +24,7 @@ There is no point learning Lean 3 at this stage.
 
 * If you prefer reading a book (with exercises), the standard mathematics oriented reference is
   [Mathematics in Lean](https://leanprover-community.github.io/mathematics_in_lean/).
-  You can also download it 
+  You can also download it
   [as a pdf](https://leanprover-community.github.io/mathematics_in_lean/mathematics_in_lean.pdf),
   but it is really meant to be used in VSCode, doing exercises on the fly (see the
   [instructions](https://leanprover-community.github.io/mathematics_in_lean/C01_Introduction.html#getting-started)).
@@ -33,12 +33,17 @@ There is no point learning Lean 3 at this stage.
   It has a gentler pace than *Mathematics in Lean* and is aimed at readers with less mathematical
   experience.
 
-* If you prefer something more computer-science oriented, the standard reference is
-  [Theorem Proving in Lean](https://leanprover.github.io/theorem_proving_in_lean4/).
-  You almost certainly want to read it at some point anyway, since it
-  contains a lot more explanations about foundational things.
+* [Formalising Mathematics](https://www.ma.imperial.ac.uk/~buzzard/xena/formalising-mathematics-2024/)
+  is another book for mathematicians with useful tips and an overview of common tactics.
 
-* If you want something that is more focussed on Lean itself than on using Lean, then you 
+* If you prefer something more about the foundations of type theory, the standard reference is
+  [Theorem Proving in Lean](https://leanprover.github.io/theorem_proving_in_lean4/).
+
+* A computer-science/programming oriented book is
+  [The Hitchhiker's Guide to Logical Verification](https://raw.githubusercontent.com/blanchette/logical_verification_2023/main/hitchhikers_guide.pdf),
+  which also has useful information about the type theory of Lean.
+
+* If you want something that is more focussed on Lean itself than on using Lean, then you
   can read the [reference manual](https://leanprover.github.io/lean4/doc/).
 
 ## (Meta)-programming and tactic writing
@@ -89,11 +94,9 @@ be of interest. Note that all items until year 2022 used Lean 3 but may still co
 * [Lean for the Curious Mathematician 2023](https://lftcm2023.github.io/tutorial/index.html)
 * [Formalization of mathematics 2023](https://www.msri.org/summer_schools/1021)
 * [Lean for the Curious Mathematician 2022](https://icerm.brown.edu/topical_workshops/tw-22-lean/)
-* [Lean Together 2021](https://leanprover-community.github.io/lt2021/)
 * [Lean for the Curious Mathematician 2020](https://leanprover-community.github.io/lftcm2020/)
-* [Formal Methods in Mathematics / Lean Together 2020](https://www.andrew.cmu.edu/user/avigad/meetings/fomm2020/)
-* [Lean Together 2019](https://lean-forward.github.io/lean-together/2019/)
 
+More events can be found on the [events](events.html) page.
 We also have a [YouTube channel](https://www.youtube.com/channel/UCWe5B7Ikr0AI9727doEUxPg/playlists)
 which includes playlists of videos from the above conferences, and also other conferences with Lean-relevant content.
 

--- a/templates/learn.md
+++ b/templates/learn.md
@@ -34,7 +34,7 @@ There is no point learning Lean 3 at this stage.
   experience.
 
 * [Formalising Mathematics](https://www.ma.imperial.ac.uk/~buzzard/xena/formalising-mathematics-2024/)
-  is another book for mathematicians with useful tips and an overview of common tactics.
+  is some course notes for mathematicians with useful tips and an overview of common tactics.
 
 * If you prefer something more about the foundations of type theory, the standard reference is
   [Theorem Proving in Lean](https://leanprover.github.io/theorem_proving_in_lean4/).


### PR DESCRIPTION
* Add `Formalising Mathematics` book
* Add `The Hitchhiker's Guide to Logical Verification` book (this should not go under `(Meta)-programming and tactic writing` since it's still about proving, not programming).
* Change description of `Theorem Proving in Lean`
* Remove meetings that were not aimed at beginners, but link to the event page.