### PR TITLE
update Lean version used for lake new

### DIFF
--- a/templates/install/project.md
+++ b/templates/install/project.md
@@ -59,7 +59,7 @@ We will now create a new project depending on mathlib. The following
 commands should be typed in a terminal.
 
 * Go to a folder where you want to create a project in a subfolder
-  `my_project`, and type `lake +leanprover/lean4:nightly-2023-02-04 new my_project math`. Do not worry about the date in the previous command, it ensures you will use a sufficiently recent version of `lake` but has no impact on the version of `lean` your project will use. If you get an
+  `my_project`, and type `lake +leanprover/lean4:nightly-2024-04-24 new my_project math`. Do not worry about the date in the previous command, it ensures you will use a sufficiently recent version of `lake` but has no impact on the version of `lean` your project will use. If you get an
   error message saying `lake` is an unknown command and
   you have not logged in since you installed Lean, then
   you may need to first type `source ~/.profile` or `source ~/.bash_profile`.
@@ -127,7 +127,7 @@ Some Windows users have reported an error like this when running `lake exe cache
 
 If you see this error, you likely have an antivirus program that scans each downloaded file, which results in errors.
 Please disable your antivirus program and then run `lake exe cache get!`.
-The exclamation mark forces `lake` to re-download the cache files it failed to download before running this command. 
+The exclamation mark forces `lake` to re-download the cache files it failed to download before running this command.
 (If you are uncomfortable disabling your antivirus, try to follow [these instructions](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/lake.20exe.20cache.20get.20errors/near/389019448)
 and then run `lake exe cache get!`).
 You can turn on your antivirus program on afterwards.


### PR DESCRIPTION
The old version of lake creates a wrong `.gitignore`.

Alternatively, we use the instructions from [the wiki](https://github.com/leanprover-community/mathlib4/wiki/Using-mathlib4-as-a-dependency):
```
lake +leanprover-community/mathlib4:lean-toolchain new <your_project_name> math
```
but that will require an `elan self update` first for many users (including me).