### PR TITLE
add updating and troubleshooting instructions, remove hosting

### DIFF
--- a/templates/install/project.md
+++ b/templates/install/project.md
@@ -66,7 +66,7 @@ commands should be typed in a terminal.
 The keyword `math` at the end of this command adds `mathlib4` to the dependencies of your project, so that you can use `import Mathlib` in your project files.
 
 * Go inside the `my_project` folder and type `lake update` and then `mkdir MyProject`.
-  * Windows users seeing a `curl: (35) schannel: next InitializeSecurityContext failed` error should read [this note](#initializesecuritycontext-error-on-windows).
+  * Windows users seeing a `curl: (35) schannel: next InitializeSecurityContext failed` error should read [this note](#troubleshooting).
 
 * Launch VS Code, either through your application menu or by typing
   the `code .` command.
@@ -104,22 +104,28 @@ Also, you can get the Lean documentation inside VS Code using
 inside the text field that appears, type "lean doc" and hit <kbd>Enter</kbd>.
 Then click "Mathematics in Lean" or "Theorem Proving in Lean" and enjoy.
 
-## Hosting your project on GitHub
+## Updating Mathlib in your project
 
-Your project is already a git repository, and as it grows,
-you may want to host it on [GitHub](https://guides.github.com/activities/hello-world/).
-If you take this step, the community offers some
-[GitHub Actions scripts](../ci.html) that could help manage your repository.
-But don't worry if you don't know what this means.
-It's not necessary for using Lean.
+If you have a project depending on Mathlib, and you want to update to the latest version of Lean and Mathlib, you have to do two steps:
+* Update the `lean-toolchain` file in your repository to the latest version. You can do this automatically by running the following in the root directory of your repository.
+```
+curl https://raw.githubusercontent.com/leanprover-community/mathlib4/master/lean-toolchain > lean-toolchain
+```
+* run `lake update`. This will update Lean, Mathlib and download the new Mathlib cache for you.
+
+You should then check whether all files in your repository still compile. The most convenient way to do this is to have a root file that imports all files in your repository. You can do this by running the following (replace `MyProject` twice by your project name):
+```
+find MyProject -name "*.lean" | env LC_ALL=C sort | sed 's/\.lean//;s,/,.,g;s/^/import /' > MyProject.lean
+```
+After that, you can run `lake build` to build all files in your repository.
 
 ## Contributing to mathlib
 
 See [How to contribute to mathlib](https://leanprover-community.github.io/contribute/index.html).
 
-## InitializeSecurityContext error on Windows
+## Troubleshooting
 
-Some Windows users have reported an error like this when running `lake exe cache get`:
+* Some Windows users have reported an error like this when running `lake exe cache get`:
 
 ```
   curl: (35) schannel: next InitializeSecurityContext failed: Unknown error (0x80092012) - The revocation function was unable to check revocation for the certificate
@@ -133,3 +139,18 @@ and then run `lake exe cache get!`).
 You can turn on your antivirus program on afterwards.
 However, some users also reported that the antivirus programs significantly slow down Lean during normal usage.
 If Lean is slower than what is expected, either turn off your antivirus program or tell it to ignore/allow the operation of `lean.exe`.
+
+* Sometimes under Windows a corrupted version of Lean is downloaded while installing/updating Lean. If this happens, this will result in an error
+```
+uncaught exception: no such file or directory (error code: 2)
+```
+If this happens, you can manually delete your corrupted version of Lean by following the following two steps:
+  - Go to your user folder and navigate to `.elan > toolchains` (typically `C:\Users\<username>\.elan\toolchains`), and delete the offending toolchain
+  - Go to `.elan > update-hashes` (e.g. `C:\Users\<username>\.elan\update-hashes`) and delete the file with the same name.
+The toolchain will be automatically redownloaded the next time you call `lake update`, `lake exe cache get`, `lake build` or open a Lean file in VSCode in a repository that uses that toolchain.
+
+* If you would like to cleanup Lean files, these are stored in the following places.
+  - Dependencies of a project are in the `.lake` folder of that project.
+  - Lean toolchains are stored in `~/.elan/toolchains`. You can safely delete old toolchains from here. Whenever you delete toolchains, you should also delete the corresponding files from `~/.elan/update-hashes`.
+  - Compressed and compiled Mathlib files are stored in `~/.cache/mathlib`. These can be safely deleted.
+  - Lean 3 users might still have a folder `.mathlib` in their user directory.

--- a/templates/install/project.md
+++ b/templates/install/project.md
@@ -119,6 +119,8 @@ find MyProject -name "*.lean" | env LC_ALL=C sort | sed 's/\.lean//;s,/,.,g;s/^/
 ```
 After that, you can run `lake build` to build all files in your repository.
 
+More information about Lake can be found [here](https://github.com/leanprover/lean4/tree/master/src/lake).
+
 ## Contributing to mathlib
 
 See [How to contribute to mathlib](https://leanprover-community.github.io/contribute/index.html).

--- a/templates/install/project.md
+++ b/templates/install/project.md
@@ -113,7 +113,10 @@ curl -L https://raw.githubusercontent.com/leanprover-community/mathlib4/master/l
 ```
 * run `lake -R -Kenv=dev update`. This will update Lean, Mathlib and download the new Mathlib cache for you.
 
-You should then check whether all files in your repository still compile. The most convenient way to do this is to have a root file that imports all files in your repository. You can do this by running the following (replace `MyProject` twice by your project name):
+You should then check whether all files in your repository still compile.
+The most convenient way to do this is to run `lake exe mk_all`. However, that might not work on Windows at the moment.
+The manual way is to have a root file that imports all files in your repository.
+You can do this by running the following (replace `MyProject` by your project name twice):
 ```
 find MyProject -name "*.lean" | env LC_ALL=C sort | sed 's/\.lean//;s,/,.,g;s/^/import /' > MyProject.lean
 ```

--- a/templates/install/project.md
+++ b/templates/install/project.md
@@ -111,16 +111,10 @@ If you have a project depending on Mathlib, and you want to update to the latest
 ```
 curl -L https://raw.githubusercontent.com/leanprover-community/mathlib4/master/lean-toolchain -o lean-toolchain
 ```
-* run `lake -R -Kenv=dev update`. This will update Lean, Mathlib and download the new Mathlib cache for you.
+* run `lake update`. This will update Lean, Mathlib and download the new Mathlib cache for you. (Note: on project that use `leanblueprint`/`doc-gen`, you currently have to run `lake -R -Kenv=dev update`).
 
 You should then check whether all files in your repository still compile.
-The most convenient way to do this is to run `lake exe mk_all`. However, that might not work on Windows at the moment.
-The manual way is to have a root file that imports all files in your repository.
-You can do this by running the following (replace `MyProject` by your project name twice):
-```
-find MyProject -name "*.lean" | env LC_ALL=C sort | sed 's/\.lean//;s,/,.,g;s/^/import /' > MyProject.lean
-```
-After that, you can run `lake build` to build all files in your repository.
+You can do this by running `lake exe mk_all && lake build`.
 
 More information about Lake can be found [here](https://github.com/leanprover/lean4/tree/master/src/lake).
 

--- a/templates/install/project.md
+++ b/templates/install/project.md
@@ -109,9 +109,9 @@ Then click "Mathematics in Lean" or "Theorem Proving in Lean" and enjoy.
 If you have a project depending on Mathlib, and you want to update to the latest version of Lean and Mathlib, you have to do two steps:
 * Update the `lean-toolchain` file in your repository to the latest version. You can do this automatically by running the following in the root directory of your repository.
 ```
-curl https://raw.githubusercontent.com/leanprover-community/mathlib4/master/lean-toolchain > lean-toolchain
+curl -L https://raw.githubusercontent.com/leanprover-community/mathlib4/master/lean-toolchain -o lean-toolchain
 ```
-* run `lake update`. This will update Lean, Mathlib and download the new Mathlib cache for you.
+* run `lake -R -Kenv=dev update`. This will update Lean, Mathlib and download the new Mathlib cache for you.
 
 You should then check whether all files in your repository still compile. The most convenient way to do this is to have a root file that imports all files in your repository. You can do this by running the following (replace `MyProject` twice by your project name):
 ```


### PR DESCRIPTION
* Add detailed update instructions
* The hosting section was mostly there to link to `ci.html` which was removed.
* Add troubleshooting instructions when a corrupted Lean version was downloaded
* Add instructions to clean-up old Lean versions/Mathlib cache.

fixes #489