### PR TITLE
chore: update MacOS instructions to remove Homebrew references

### DIFF
--- a/templates/install/macos_details.md
+++ b/templates/install/macos_details.md
@@ -18,8 +18,10 @@ Installing `elan` and mathlib supporting tools
 1.  Grab the [latest release](https://github.com/leanprover/elan/releases/latest) for your architecture,
     unpack it, and run the contained installation program.
 
-    The installation will tell you where it will install elan to (~/.elan by default),
-    and also ask you about editing your shell config to extend PATH. elan can be uninstalled via elan self uninstall, which should revert these changes.
+    The installation will tell you where it will install `elan` to (`~/.elan` by default),
+    and also ask you about editing your shell config to extend `PATH`. `elan` can be uninstalled via `elan self uninstall`, which should revert these changes.
+    
+(We discourage using the `homebrew` provided `elan-init` package, as users often find that this lags behind updates to the official release. We especially discourage using the `homebrew` formula named simply `lean`, which installs a fixed version of Lean.)
 
 2.  Use `elan` to install the latest stable version of `lean` by running
     `elan toolchain install stable`. You can also set the newly-installed

--- a/templates/install/macos_details.md
+++ b/templates/install/macos_details.md
@@ -15,17 +15,13 @@ all users.
 Installing `elan` and mathlib supporting tools
 ---
 
-1.  Install [Homebrew](https://brew.sh/) if you do not already have it installed.
+1.  Grab the [latest release](https://github.com/leanprover/elan/releases/latest) for your architecture,
+    unpack it, and run the contained installation program.
 
-2.  Run `brew install elan-init` in a terminal window to
-    install `elan`.
+    The installation will tell you where it will install elan to (~/.elan by default),
+    and also ask you about editing your shell config to extend PATH. elan can be uninstalled via elan self uninstall, which should revert these changes.
 
-    Note that Homebrew also contains a formula named simply `lean`, but
-    that it installs a fixed version of Lean, rather than one provisioned
-    with `elan` as per the above.  Using this formula is as mentioned *not*
-    recommended.
-
-3.  Use `elan` to install the latest stable version of `lean` by running
+2.  Use `elan` to install the latest stable version of `lean` by running
     `elan toolchain install stable`. You can also set the newly-installed
     version to be the default version of `lean` you get when running outside of
     a project (discussed below) by running `elan default stable`.
@@ -35,7 +31,7 @@ Installing and configuring an editor
 
 There are three editors you can use with Lean, VS Code emacs and neovim.
 This document describes using VS Code which currently has the best support for Lean.
-For emacs, look at https://github.com/leanprover/lean4-mode. 
+For emacs, look at https://github.com/leanprover/lean4-mode.
 For neovim, look at https://github.com/Julian/lean.nvim)
 
 1. Install [VS Code](https://code.visualstudio.com/).


### PR DESCRIPTION
Homebrew `elan-init` lags in version and can be confusing to find. Change the detailed install instructions to reference the released installers. 