### PR TITLE
chore: update details for Lean for Scientists and Engineers

### DIFF
--- a/data/courses.yaml
+++ b/data/courses.yaml
@@ -23,7 +23,7 @@
   institution: University of Maryland, Baltimore County
   year: 2024
   lean_version: 4
-  summary:  Introducing to Lean proofs and programming for scientists and engineers. Prerequisite: Calculus II. Students should learn basic proofs (up to some calculus examples) and basic programming techniques (I/O, functional programming, arrays) to inspire and enable development of scientific computing software connected to formalized scientific derivations in Lean.
+  summary:  "Introducing to Lean proofs and programming for scientists and engineers. Prerequisite: Calculus II. Students should learn basic proofs (up to some calculus examples) and basic programming techniques (I/O, functional programming, arrays) to inspire and enable development of scientific computing software connected to formalized scientific derivations in Lean."
   tags: ['beginner', 'functional programming', 'intro to proof']
   website: https://leanprover.zulipchat.com/#narrow/stream/445230-Lean-for-Scientists-and-Engineers-2024/
   experiences: TBD (course being held July through August)  

--- a/data/courses.yaml
+++ b/data/courses.yaml
@@ -24,8 +24,8 @@
   year: 2024
   lean_version: 4
   summary:  Introducing to Lean proofs and programming for scientists and engineers. Prerequisite: Calculus II. Students should learn basic proofs (up to some calculus examples) and basic programming techniques (I/O, functional programming, arrays) to inspire and enable development of scientific computing software connected to formalized scientific derivations in Lean.
-  tags: ['English', 'beginner', 'functional programming', 'intro to proof']
-  website: https://forms.gle/Pq1HXBEB7unhUr5H9
+  tags: ['beginner', 'functional programming', 'intro to proof']
+  website: https://leanprover.zulipchat.com/#narrow/stream/445230-Lean-for-Scientists-and-Engineers-2024/
   experiences: TBD (course being held July through August)  
 - name: Introduction to Mathematical Formalization
   instructor: Vasily Ilin


### PR DESCRIPTION
The website was a signup link: as notes and videos are being posted on zulip, that seems a more useful link now.

Also removing "English" as this is the default.