### PR TITLE
make sure the example copyright header would pass CI

### DIFF
--- a/templates/contribute/style.md
+++ b/templates/contribute/style.md
@@ -53,11 +53,11 @@ import Mathlib.Algebra.Group.Defs
 (Tip: If you're editing mathlib in VS Code, you can write `copy`
 and then press <kbd>TAB</kbd> to generate a skeleton of the copyright header.)
 
-Regarding the list of authors: use `Authors` even when there is only a single author. 
-Don't end the line with a period, and use commas (`, `) to separate all author names 
-(so don't use `and` between the penultimate and ultimate author.) 
-We don't have strict rules on what contributions qualify for inclusion there. 
-The general idea is that the people listed there should be the ones we would 
+Regarding the list of authors: use `Authors` even when there is only a single author.
+Don't end the line with a period, and use commas (`, `) to separate all author names
+(so don't use `and` between the penultimate and ultimate author.)
+We don't have strict rules on what contributions qualify for inclusion there.
+The general idea is that the people listed there should be the ones we would
 reach out to if we had questions about the design or development of the Lean code.
 
 ### Module docstrings

--- a/templates/contribute/style.md
+++ b/templates/contribute/style.md
@@ -42,9 +42,9 @@ without a line break, on separate lines.
 
 ```lean
 /-
-Copyright (c) 2015 Joe Cool. All rights reserved.
+Copyright (c) 2024 Joe Cool. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Joe Cool.
+Authors: Joe Cool
 -/
 import Mathlib.Data.Nat.Basic
 import Mathlib.Algebra.Group.Defs

--- a/templates/contribute/style.md
+++ b/templates/contribute/style.md
@@ -53,10 +53,12 @@ import Mathlib.Algebra.Group.Defs
 (Tip: If you're editing mathlib in VS Code, you can write `copy`
 and then press <kbd>TAB</kbd> to generate a skeleton of the copyright header.)
 
-Regarding the list of authors: we don't have strict rules on what
-contributions qualify for inclusion there. The general idea is that
-the people listed there should be the ones we would reach out to if we had
-questions about the design or development of the Lean code.
+Regarding the list of authors: use `Authors` even when there is only a single author. 
+Don't end the line with a period, and use commas (`, `) to separate all author names 
+(so don't use `and` between the penultimate and ultimate author.) 
+We don't have strict rules on what contributions qualify for inclusion there. 
+The general idea is that the people listed there should be the ones we would 
+reach out to if we had questions about the design or development of the Lean code.
 
 ### Module docstrings
 


### PR DESCRIPTION
the linter checking the header matches on `Authors:` and makes sure the line doesn't end in `.`, so it would fail on the example. also make the year current, while we're at it.