### PR TITLE
Add Loogle to sidebar links

### DIFF
--- a/data/menus.yaml
+++ b/data/menus.yaml
@@ -24,6 +24,7 @@
   items:
     - Learning resources (start here): learn.html
     - API documentation: https://leanprover-community.github.io/mathlib4_docs
+    - Declaration search (Loogle): https://loogle.lean-lang.org/
     - Calc mode: extras/calc.html
     - Conv mode: extras/conv.html
     - Simplifier: extras/simp.html


### PR DESCRIPTION
I stumbled across Loogle recently. It doesn't appear to be mentioned on the learning resources page yet.

This also changes the link to mathlib4_docs from "API documentation" to "General documentation". I think this is a lot clearer (and is what mathlib4_docs calls itself): when I was first poking around with Lean I thought this was some sort of FFI documentation, and didn't realize it is the primary documentation page for the language.