### PR TITLE
feat: add dependency graph

### DIFF
--- a/templates/mathlib_stats.html
+++ b/templates/mathlib_stats.html
@@ -32,6 +32,14 @@
 
       <canvas id="by_year"></canvas>
 
+      <h2>Dependency graph</h2>
+
+      <p>
+        A visualization showing how the various topics in mathlib interact and their
+        relative sizes can be found
+        <a href="{{ base_url }}/mathlib4_docs/mathlib.html">here</a>.
+      </p>
+
 {% endblock %}
 
 {% block extrajs %}

--- a/templates/mathlib_stats.html
+++ b/templates/mathlib_stats.html
@@ -36,8 +36,7 @@
 
       <p>
         A visualization showing how the various topics in mathlib interact and their
-        relative sizes can be found
-        <a href="{{ base_url }}/mathlib4_docs/mathlib.html">here</a>.
+        relative sizes can be found <a href="{{ base_url }}/mathlib4_docs/mathlib.html">here</a>.
       </p>
 
 {% endblock %}


### PR DESCRIPTION
Restore the dependency graph, which used to exist for Lean 3 and was originally added in #218.

- [x] depends on: leanprover-community/mathlib4_docs#3
