### PR TITLE
Induction naming convention

### DIFF
--- a/templates/contribute/naming.md
+++ b/templates/contribute/naming.md
@@ -421,7 +421,7 @@ and a bidirectional lemma is needed, it may be named `.inj_iff`.
 
 Inductive/recursive principles are ways to construct data or proofs for all elements of some type `T`,
 by providing ways to construct this data or proof in more constrained specific contexts. 
-These principles generally are phrased to first accept a *motive*,
+These principles should be phrased to accept a `motive` argument,
 which declares what property we are proving or what data we are constructing for all `T`.
 When the motive eliminates into `Prop`, it is an induction principle, and the name should contain
 `induction`. On the other hand, when the motive eliminates into `Sort u` or `Type u`,

--- a/templates/contribute/naming.md
+++ b/templates/contribute/naming.md
@@ -436,4 +436,4 @@ The following table summarizes these naming conventions.
 | value first             | `T.induction_on` | `T.recOn`            |
 | constructions first     | `T.induction`    | `T.rec`              |
 
-Variation on these names are acceptable when neccessary (e.g. for disambiguation)
+Variation on these names are acceptable when necessary (e.g. for disambiguation)

--- a/templates/contribute/naming.md
+++ b/templates/contribute/naming.md
@@ -431,9 +431,9 @@ Additionally, the name should contain `on` iff in the argument order, the value 
 
 The following table summarizes these naming conventions.
 
-|motive eliminates into: | `Prop`           | `Sort u` or `Type u`|
-|------------------------|------------------|---------------------|
-| value first            | `T.induction_on` | `T.recOn`           |
-| constructions first    | `T.induction`    | `T.rec`             |
+| motive eliminates into: | `Prop`           | `Sort u` or `Type u` |
+|-------------------------|------------------|----------------------|
+| value first             | `T.induction_on` | `T.recOn`            |
+| constructions first     | `T.induction`    | `T.rec`              |
 
 Variation on these names are acceptable when neccessary (e.g. for disambiguation)

--- a/templates/contribute/naming.md
+++ b/templates/contribute/naming.md
@@ -441,6 +441,6 @@ The following table summarizes these naming conventions.
 Variation on these names are acceptable when neccessary (e.g. for disambiguation)
 
 ------
-Copyright (c) 2023 Jeremy Avigad. All rights reserved.
+Copyright (c) 2024 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Edward van de Meent

--- a/templates/contribute/naming.md
+++ b/templates/contribute/naming.md
@@ -416,9 +416,9 @@ and there is no intention to change this.
 When such an automatically generated lemma already exists,
 and a bidirectional lemma is needed, it may be named `.inj_iff`.
 
-### Inductive and recursive principles
+### Induction and recursion principles
 
-Inductive/recursive principles are ways to construct data or proofs for all elements of some type `T`,
+Induction/recursion principles are ways to construct data or proofs for all elements of some type `T`,
 by providing ways to construct this data or proof in more constrained specific contexts. 
 These principles should be phrased to accept a `motive` argument,
 which declares what property we are proving or what data we are constructing for all `T`.
@@ -428,14 +428,14 @@ it is a recursive principle, and the name should contain `rec` instead.
 
 Additionally, the name should contain `on` iff in the argument order, the value comes before the constructions.
 
-The following table summarizes these naming conventions.
+The following table summarizes these naming conventions:
 
 | motive eliminates into: | `Prop`           | `Sort u` or `Type u` |
 |-------------------------|------------------|----------------------|
 | value first             | `T.induction_on` | `T.recOn`            |
 | constructions first     | `T.induction`    | `T.rec`              |
 
-Variation on these names are acceptable when necessary (e.g. for disambiguation)
+Variation on these names are acceptable when necessary (e.g. for disambiguation).
 
 ### Predicates as suffixes
 

--- a/templates/contribute/naming.md
+++ b/templates/contribute/naming.md
@@ -1,6 +1,6 @@
 # Mathlib naming conventions
 
-Author: [Jeremy Avigad](http://www.andrew.cmu.edu/user/avigad)
+Authors: [Jeremy Avigad](http://www.andrew.cmu.edu/user/avigad), Edward van de Meent
 
 This guide is written for Lean 4.
 
@@ -419,7 +419,28 @@ and there is no intention to change this.
 When such an automatically generated lemma already exists,
 and a bidirectional lemma is needed, it may be named `.inj_iff`.
 
+### Inductive and recursive principles
+
+Inductive/recursive principles are ways to construct data or proofs for all elements of some type `T`,
+by providing ways to construct this data or proof in more constrained specific contexts. 
+These principles generally are phrased to first accept a *motive*,
+which declares what property we are proving or what data we are constructing for all `T`.
+When the motive eliminates into `Prop`, it is an induction principle, and the name should contain
+`induction`. On the other hand, when the motive eliminates into `Sort u` or `Type u`,
+it is a recursive principle, and the name should contain `rec` instead.
+
+Additionally, the name should contain `on` iff in the argument order, the value comes before the constructions.
+
+The following table summarizes these naming conventions.
+
+|motive eliminates into: | `Prop` | `Sort u` or `Type u`|
+|----------------------|------------------|-----------|
+| value first          | `T.induction_on` | `T.recOn` |
+| constructions first  | `T.induction`    | `T.rec`   |
+
+Variation on these names are acceptable when neccessary (e.g. for disambiguation)
+
 ------
-Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Copyright (c) 2023 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jeremy Avigad
+Authors: Jeremy Avigad, Edward van de Meent

--- a/templates/contribute/naming.md
+++ b/templates/contribute/naming.md
@@ -431,9 +431,9 @@ Additionally, the name should contain `on` iff in the argument order, the value 
 
 The following table summarizes these naming conventions.
 
-|motive eliminates into: | `Prop` | `Sort u` or `Type u`|
-|----------------------|------------------|-----------|
-| value first          | `T.induction_on` | `T.recOn` |
-| constructions first  | `T.induction`    | `T.rec`   |
+|motive eliminates into: | `Prop`           | `Sort u` or `Type u`|
+|------------------------|------------------|---------------------|
+| value first            | `T.induction_on` | `T.recOn`           |
+| constructions first    | `T.induction`    | `T.rec`             |
 
 Variation on these names are acceptable when neccessary (e.g. for disambiguation)


### PR DESCRIPTION
This PR adds a naming convention for induction/recursion principles.
see also the [zulip topic](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Induction.20argument.20order)