### PR TITLE
Remove authorship and copyright from doc pages

### DIFF
--- a/templates/contribute/naming.md
+++ b/templates/contribute/naming.md
@@ -1,7 +1,5 @@
 # Mathlib naming conventions
 
-Author: [Jeremy Avigad](http://www.andrew.cmu.edu/user/avigad)
-
 This guide is written for Lean 4.
 
 ## General conventions
@@ -418,8 +416,3 @@ automatically generated unidirectional implications, named `.inj`,
 and there is no intention to change this.
 When such an automatically generated lemma already exists,
 and a bidirectional lemma is needed, it may be named `.inj_iff`.
-
-------
-Copyright (c) 2016 Jeremy Avigad. All rights reserved.
-Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jeremy Avigad

--- a/templates/contribute/pr-review.md
+++ b/templates/contribute/pr-review.md
@@ -1,7 +1,5 @@
 # Pull Request Review Guide
 
-Author: Jireh Loreaux
-
 This guide provides a detailed look at how to conduct PR reviews for mathlib. You may
 wonder whether this guide applies to you, and the answer is "yes!"
 

--- a/templates/contribute/style.md
+++ b/templates/contribute/style.md
@@ -1,5 +1,4 @@
 # Library Style Guidelines
-Author: [Jeremy Avigad](http://www.andrew.cmu.edu/user/avigad)
 
 In addition to the [naming conventions](naming.html),
 files in the Lean library generally adhere to the following guidelines
@@ -553,8 +552,3 @@ Documentation strings for declarations are delimited with `/-- -/`.
 
 See our [documentation requirements](doc.html) for more suggestions
 and examples.
-
-------
-Copyright (c) 2016 Jeremy Avigad. All rights reserved.
-Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jeremy Avigad, Jireh Loreaux


### PR DESCRIPTION
This makes them consistent with the other documents.

While Jeremy authored these in Lean 2, they are now community-maintained documents, and listing all the authors involved isn't really that interesting.