### PR TITLE
Update the contribution guide

### DIFF
--- a/templates/contribute/commit.md
+++ b/templates/contribute/commit.md
@@ -81,15 +81,17 @@ docs(CategoryTheory/EssentialImage): typo and punctuation
 Fix a typo, add two periods.
 ```
 
-an example with dependent PRs:
+An example with dependent PRs:
 
 ```markdown
 feat: The norm on `Unitization` is a C⋆-norm
 
 This shows that C⋆-algebras are always `RegularNormedAlgebra`s, so that their `Unitization` is equipped with a norm. Moreover, we show this norm is a C⋆-norm.
 
+---
+
 - [ ] depends on: #5330
 - [ ] depends on: #5741
-- [ ] depends on: #5742 
-- [ ] depends on: #5743 
+- [ ] depends on: #5742
+- [ ] depends on: #5743
 ```


### PR DESCRIPTION
As pointed out in https://github.com/leanprover-community/leanprover-community.github.io/pull/359#discussion_r1312346046, `- [ ] depends on:` should be below the `---`. I think most people already place it in the correct position because the template tells them so, but we might as well update the contribution guide too.