### PR TITLE
Add MathIR course from Göttingen

### DIFF
--- a/data/courses.yaml
+++ b/data/courses.yaml
@@ -17,7 +17,16 @@
 # a general subject (`mathematics`, `logic`, `computer science`).
 #
 # This list is not ordered. Add new entries wherever you want.
-
+- name: Seminar: Mathematical Information Retrieval (MathIR)
+  instructor: André Greiner-Petter, Moritz Schubotz, Bela Gipp
+  institution: University of Göttingen, Germany
+  lean_version: 4
+  tags: ['mathematics', 'beginner', 'computer science']
+  summary: >
+    In this seminar, students will contribute to an open-source system to solve applied real-world problems. Since 2024, we have offered projects related to [mathlib](https://github.com/leanprover-community/mathlib4).
+    We recommend choosing one of the ["good first issues"](https://github.com/leanprover-community/mathlib4/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) from GitHub.
+  website: https://gipplab.org/teaching/mathir/
+  year: 2024
 - name: Introduction to Lean and Advanced projects on Lean
   instructor: Sophie Morel, Filippo A. E. Nuccio, Xavier Roblot
   institution: ENS-Lyon, Université Claude Bernard Lyon, Université Jean Monnet Saint-Étienne


### PR DESCRIPTION
Since the WS24/25 semester, we have been offering practical problems related to Mathlib.