### PR TITLE
chore: add tags to all ITP24 papers

### DIFF
--- a/lean.bib
+++ b/lean.bib
@@ -71,7 +71,8 @@
   urn           = {urn:nbn:de:0030-drops-207347},
   doi           = {10.4230/LIPIcs.ITP.2024.6},
   annote        = {Keywords: Condensed mathematics, N\"{o}beling’s theorem,
-                  Lean, Mathlib, Interactive theorem proving}
+                  Lean, Mathlib, Interactive theorem proving},
+  tags          = {formalization, lean4}
 }
 
 @Book{            Avig14,
@@ -236,7 +237,8 @@
   urn           = {urn:nbn:de:0030-drops-207368},
   doi           = {10.4230/LIPIcs.ITP.2024.8},
   annote        = {Keywords: Lean, Directed Topology, Van Kampen Theorem,
-                  Directed Homotopy Theory, Formalised Mathematics}
+                  Directed Homotopy Theory, Formalised Mathematics},
+  tags          = {formalization, lean4}
 }
 
 @Booklet{         Best2021,
@@ -292,7 +294,8 @@
   urn           = {urn:nbn:de:0030-drops-207372},
   doi           = {10.4230/LIPIcs.ITP.2024.9},
   annote        = {Keywords: compilers, semantics, mechanization, MLIR, SSA,
-                  regions, peephole rewrites}
+                  regions, peephole rewrites},
+  tags          = {formalization, lean4}
 }
 
 @Article{         BordgCavalleri2021,
@@ -443,7 +446,8 @@
   urn           = {urn:nbn:de:0030-drops-207381},
   doi           = {10.4230/LIPIcs.ITP.2024.10},
   annote        = {Keywords: proof search, automatic theorem proving,
-                  interactive theorem proving, Lean, dependent type theory}
+                  interactive theorem proving, Lean, dependent type theory},
+  tags          = {formalization, lean4}
 }
 
 @InProceedings{   CommelinLewis21,
@@ -810,7 +814,8 @@
   urn           = {urn:nbn:de:0030-drops-207690},
   doi           = {10.4230/LIPIcs.ITP.2024.41},
   annote        = {Keywords: Interactive theorem proving, Lean4, Graphical
-                  User Interface}
+                  User Interface},
+  tags          = {formalization, lean4}
 }
 
 @Misc{            FernandezMir19,
@@ -1152,7 +1157,8 @@
   urn           = {urn:nbn:de:0030-drops-207550},
   doi           = {10.4230/LIPIcs.ITP.2024.27},
   annote        = {Keywords: mathematics teaching, proof assistant,
-                  controlled natural language}
+                  controlled natural language},
+  tags          = {formalization, lean4}
 }
 
 @InProceedings{   Mathlib,
@@ -1281,7 +1287,8 @@
   doi           = {10.4230/LIPIcs.ITP.2024.28},
   annote        = {Keywords: Multi-agent systems, Coalition Logic, Epistemic
                   Logic, common knowledge, completeness, formal methods, Lean
-                  prover}
+                  prover},
+  tags          = {formalization, lean4}
 }
 
 @Article{         PNWT22,
@@ -1520,7 +1527,8 @@
   urn           = {urn:nbn:de:0030-drops-207633},
   doi           = {10.4230/LIPIcs.ITP.2024.35},
   annote        = {Keywords: Empty Hexagon Number, Discrete Computational
-                  Geometry, Erd\H{o}s-Szekeres}
+                  Geometry, Erd\H{o}s-Szekeres},
+  tags          = {formalization, lean4}
 }
 
 @InProceedings{   TassarottiVBT21,
@@ -1649,7 +1657,8 @@
   urn           = {urn:nbn:de:0030-drops-207657},
   doi           = {10.4230/LIPIcs.ITP.2024.37},
   annote        = {Keywords: Sobolev inequality, measure theory, Lean,
-                  formalized mathematics}
+                  formalized mathematics},
+  tags          = {formalization, lean4}
 }
 
 @Misc{            VonRaumer15,


### PR DESCRIPTION
I verified that all are using Lean 4.
I am reasonably confident that 'formalization' is a reasonable categorisation of them all; I'm happy to change the tag for the *duper* paper.