### PR TITLE
LT 2025

### DIFF
--- a/data/events.yaml
+++ b/data/events.yaml
@@ -333,3 +333,10 @@
   start_date: June 9 2025
   end_date: June 13 2025
   type: workshop
+
+- title: "Lean Together 2025"
+  location: virtual
+  type: workshop
+  url: https://leanprover.zulipchat.com/#narrow/channel/113486-announce/topic/Lean.20Together.202025/near/483982662 
+  start_date: January 14 2025
+  end_date: January 17 2025


### PR DESCRIPTION
The current URL is the Zulip announcement, we are working on a proper website and we will update the link.