### PR TITLE
fix: separate multiple authors by ' and ', not a comma

### DIFF
--- a/templates/100.html
+++ b/templates/100.html
@@ -10,7 +10,7 @@
 
     {% for theorem in hundred_theorems|selectattr('author') %}
         <h5 class="markdown-heading mt-5" id="{{ theorem.number }}">{{ theorem.number }}. {{ theorem.title }} <a class="hover-link" href="#{{ theorem.number }}">#</a></h5>
-        <p>Author{% if ',' in theorem.author %}s{% endif %}: {{ theorem.author }}</p>
+        <p>Author{% if ' and ' in theorem.author %}s{% endif %}: {{ theorem.author }}</p>
         {% if theorem.statement %}<p><code>{{ theorem.statement }}</code></p>{% endif %}
         {% for doc in theorem.doc_decls|default([], true) %}
         <div class="doc-stmt">{{ doc.decl_header_html }}</div>


### PR DESCRIPTION
This matches leanprover-community/mathlib4/19503.