### PR TITLE
feat: add page for tracking the 1000+ theorems list

### DIFF
--- a/make_site.py
+++ b/make_site.py
@@ -255,7 +255,7 @@ class NTheorems(Enum):
 
 def download_N_theorems(kind: NTheorems) -> dict:
     if kind == NTheorems.Hundred:
-        (fname, Type, name) = ('100.yml', HundredTheorem, 'hundred_theorems')
+        (fname, Type, name) = ('100.yaml', HundredTheorem, 'hundred_theorems')
     else:
         (fname, Type, name) = ('1000.yml', ThousandPlusTheorem, 'thousand_theorems')
     if DOWNLOAD:

--- a/make_site.py
+++ b/make_site.py
@@ -176,7 +176,9 @@ class HundredTheorem:
 
 @dataclass
 class ThousandPlusTheorem:
-    # Wikidata identifier: the letter Q followed by a string as digits, e.g. "Q1008566"
+    # Wikidata identifier (the letter Q followed by a string as digits),
+    # optionally followed by a letter (such as "A", "B" or "X" for disambiguation).
+    # "Q1008566" and "Q4724004A" are valid identifiers, for example.
     wikidata: str
     title: str
     decl: Optional[str] = None

--- a/make_site.py
+++ b/make_site.py
@@ -711,6 +711,8 @@ def render_site(target: Path, base_url: str, reloader=False, only: Optional[str]
                 ('papers.html', {'paper_lists': paper_lists}),
                 ('100.html', {'hundred_theorems': hundred_theorems}),
                 ('100-missing.html', {'hundred_theorems': hundred_theorems}),
+                ('1000.html', {'thousand_theorems': thousand_theorems}),
+                ('1000-missing.html', {'thousand_theorems': thousand_theorems}),
                 ('meet.html', {'users': users,
                                'community': read_md('community.md')
                                }),

--- a/make_site.py
+++ b/make_site.py
@@ -176,7 +176,7 @@ class HundredTheorem:
 
 @dataclass
 class ThousandPlusTheorem:
-    # Wikidata identifier, e.g. "Q1008566"
+    # Wikidata identifier: the letter Q followed by a string as digits, e.g. "Q1008566"
     wikidata: str
     title: str
     decl: Optional[str] = None
@@ -257,7 +257,7 @@ def download_N_theorems(kind: NTheorems) -> dict:
     if kind == NTheorems.Hundred:
         (fname, Type, name) = ('100.yaml', HundredTheorem, 'hundred_theorems')
     else:
-        (fname, Type, name) = ('1000.yml', ThousandPlusTheorem, 'thousand_theorems')
+        (fname, Type, name) = ('1000.yaml', ThousandPlusTheorem, 'thousand_theorems')
     if DOWNLOAD:
         download(f'https://leanprover-community.github.io/mathlib4_docs/{fname}', DATA/fname)
         with (DATA/fname).open('r', encoding='utf-8') as h_file:

--- a/make_site.py
+++ b/make_site.py
@@ -236,38 +236,39 @@ declarations = {
 num_thms = len([d for d in declarations if declarations[d].info.kind == 'theorem'])
 num_defns = len(declarations) - num_thms
 
-if DOWNLOAD:
-    download(
-        'https://leanprover-community.github.io/mathlib4_docs/100.yaml',
-        DATA/'100.yaml')
-    with (DATA/'100.yaml').open('r', encoding='utf-8') as h_file:
-        hundred_theorems = [HundredTheorem(thm,**content) for (thm,content) in yaml.safe_load(h_file).items()]
-        for h in hundred_theorems:
-            if h.decl:
-                assert not h.decls
-                h.decls = [h.decl]
-            if h.decls:
-                doc_decls = []
-                for decl in h.decls:
-                    try:
-                        decl_info = declarations[decl]
-                    except KeyError:
-                        print(f'Error: 100 theorems entry {h.number} refers to a nonexistent declaration {decl}')
-                        continue
-                    # note: the `.bmp` data files use doc-relative links
-                    header = decl_info.header.replace('href="./Mathlib/', 'href="./mathlib4_docs/Mathlib/')
-                    doc_decls.append(DocDecl(
-                        name=decl,
-                        decl_header_html = header,
+def download_N_theorems(fname: str, Type, name: str) -> dict:
+    if DOWNLOAD:
+        download(f'https://leanprover-community.github.io/mathlib4_docs/{fname}', DATA/fname)
+        with (DATA/fname).open('r', encoding='utf-8') as h_file:
+            n_theorems = [Type(thm,**content) for (thm,content) in yaml.safe_load(h_file).items()]
+            for h in n_theorems:
+                if h.decl:
+                    assert not h.decls
+                    h.decls = [h.decl]
+                if h.decls:
+                    doc_decls = []
+                    for decl in h.decls:
+                        try:
+                            decl_info = declarations[decl]
+                        except KeyError:
+                            print(f'Error: 100 theorems entry {h.number} refers to a nonexistent declaration {decl}')
+                            continue
                         # note: the `.bmp` data files use doc-relative links
-                        docs_link='/mathlib4_docs/' + decl_info.info.docLink,
-                        src_link=decl_info.info.sourceLink))
-                h.doc_decls = doc_decls
-            else:
-                h.doc_decls = []
-    pkl_dump('hundred_theorems', hundred_theorems)
-else:
-     hundred_theorems = pkl_load('hundred_theorems', dict())
+                        header = decl_info.header.replace('href="./Mathlib/', 'href="./mathlib4_docs/Mathlib/')
+                        doc_decls.append(DocDecl(
+                            name=decl,
+                            decl_header_html = header,
+                            # note: the `.bmp` data files use doc-relative links
+                            docs_link='/mathlib4_docs/' + decl_info.info.docLink,
+                            src_link=decl_info.info.sourceLink))
+                    h.doc_decls = doc_decls
+                else:
+                    h.doc_decls = []
+        pkl_dump(name, n_theorems)
+    else:
+        n_theorems = pkl_load(name, dict())
+    return n_theorems
+hundred_theorems = download_N_theorems('100.yml', HundredTheorem, 'hundred_theorems')
 
 
 def replace_link(name, id):

--- a/make_site.py
+++ b/make_site.py
@@ -174,6 +174,18 @@ class HundredTheorem:
     note: Optional[str] = None
 
 @dataclass
+class ThousandPlusTheorem:
+    # Wikidata identifier, e.g. "Q1008566"
+    number: str
+    title: str
+    decl: Optional[str] = None
+    decls: Optional[List[str]] = None
+    doc_decls: Optional[List[DocDecl]] = None
+    author: Optional[str] = None
+    links: Optional[Mapping[str, str]] = None
+    note: Optional[str] = None
+
+@dataclass
 class Event:
     title: str
     location: str
@@ -269,7 +281,7 @@ def download_N_theorems(fname: str, Type, name: str) -> dict:
         n_theorems = pkl_load(name, dict())
     return n_theorems
 hundred_theorems = download_N_theorems('100.yml', HundredTheorem, 'hundred_theorems')
-
+thousand_theorems = download_N_theorems('1000.yml', ThousandPlusTheorem, 'thousand_theorems')
 
 def replace_link(name, id):
     if name == '':

--- a/templates/100.html
+++ b/templates/100.html
@@ -8,6 +8,14 @@
         Currently {{hundred_theorems|selectattr('author')|list|length}} of them are formalized in Lean.
         We also have a page with the theorems from the list <a href="100-missing.html">not yet in Lean</a>.</p>
 
+	<p>
+	To make updates to this list, please <a href="contribute/index.html">make a pull request to mathlib</a>
+	after editing the
+	<a href="https://github.com/leanprover-community/mathlib4/blob/master/docs/100.yaml">yaml source file</a>.
+	This can be done entirely on GitHub, see
+	<a href="https://docs.github.com/en/github/managing-files-in-a-repository/editing-files-in-another-users-repository">"Editing files in another user's repository"</a>.
+	</p>
+
     {% for theorem in hundred_theorems|selectattr('author') %}
         <h5 class="markdown-heading mt-5" id="{{ theorem.number }}">{{ theorem.number }}. {{ theorem.title }} <a class="hover-link" href="#{{ theorem.number }}">#</a></h5>
         <p>Author{% if ' and ' in theorem.author %}s{% endif %}: {{ theorem.author }}</p>

--- a/templates/1000-missing.html
+++ b/templates/1000-missing.html
@@ -1,0 +1,13 @@
+{% extends '_base.html' %}
+{% block title %}Missing theorems from Freek Wiedijk's 1000+ theorems project{% endblock %}
+{% block content %}
+{% markdown %}
+# Missing theorems from [Freek Wiedijk's](https://www.cs.ru.nl/~freek/) [1000+ theorems project](https://1000-plus.github.io/)
+These theorems are not yet formalized in Lean (or, these formalisations are not entered in the database yet).
+<a href="1000.html">Here</a> is the list of the formalized theorems.
+{% for theorem in thousand_theorems|rejectattr('author') %}
+* {{ theorem.number }}: {{ theorem.title }}
+{% endfor %}
+{% endmarkdown %}
+{% endblock %}
+

--- a/templates/1000.html
+++ b/templates/1000.html
@@ -8,6 +8,14 @@
         Currently {{thousand_theorems|selectattr('author')|list|length}} of them are formalized in Lean.
         We also have a page with the theorems from the list <a href="1000-missing.html">not yet in Lean</a>.</p>
 
+	<p>
+	To make updates to this list, please <a href="contribute/index.html">make a pull request to mathlib</a>
+	after editing the
+	<a href="https://github.com/leanprover-community/mathlib4/blob/master/docs/1000.yaml">yaml source file</a>.
+	This can be done entirely on GitHub, see
+	<a href="https://docs.github.com/en/github/managing-files-in-a-repository/editing-files-in-another-users-repository">"Editing files in another user's repository"</a>.
+	</p>
+
     {% for theorem in thousand_theorems|selectattr('author') %}
         <h5 class="markdown-heading mt-5" id="{{ theorem.number }}">{{ theorem.number }}: {{ theorem.title }} <a class="hover-link" href="#{{ theorem.number }}">#</a></h5>
         <p>Author{% if ' and ' in theorem.author %}s{% endif %}: {{ theorem.author }}</p>

--- a/templates/1000.html
+++ b/templates/1000.html
@@ -1,5 +1,5 @@
 {% extends '_base.html' %}
-{% block title %}100 theorems in Lean{% endblock %}
+{% block title %}1000+ theorems in Lean{% endblock %}
 {% block content %}
 
         <h1>1000+ theorems</h1>

--- a/templates/1000.html
+++ b/templates/1000.html
@@ -1,0 +1,23 @@
+{% extends '_base.html' %}
+{% block title %}100 theorems in Lean{% endblock %}
+{% block content %}
+
+        <h1>1000+ theorems</h1>
+
+        <p><a href="https://www.cs.ru.nl/~freek/">Freek Wiedijk</a> started the <a href="https://1000-plus.github.io/">1000+ theorems project</a> tracking progress of theorem provers in formalizing named theorems on wikipedia, as a way of comparing prominent theorem provers.
+        Currently {{thousand_theorems|selectattr('author')|list|length}} of them are formalized in Lean.
+        We also have a page with the theorems from the list <a href="1000-missing.html">not yet in Lean</a>.</p>
+
+    {% for theorem in thousand_theorems|selectattr('author') %}
+        <h5 class="markdown-heading mt-5" id="{{ theorem.number }}">{{ theorem.number }}: {{ theorem.title }} <a class="hover-link" href="#{{ theorem.number }}">#</a></h5>
+        <p>Author{% if ' and ' in theorem.author %}s{% endif %}: {{ theorem.author }}</p>
+        {% if theorem.statement %}<p><code>{{ theorem.statement }}</code></p>{% endif %}
+        {% for doc in theorem.doc_decls|default([], true) %}
+        <div class="doc-stmt">{{ doc.decl_header_html }}</div>
+        <p><a href="{{ doc.docs_link }}">docs</a>, <a href="{{ doc.src_link }}">source</a></p>
+        {% endfor %}
+        {% for title, link in (theorem.links|default({}, true)).items() %}<p><a href="{{link}}">{{title}}</a></p>{% endfor %}
+        {% if theorem.note %}<p>{% markdown %}{{ theorem.note }}{% endmarkdown %}</p>{% endif %}
+    {% endfor %}
+
+{% endblock %}


### PR DESCRIPTION
Depends on https://github.com/leanprover-community/mathlib4_docs/pull/5.
Details of the generated webpage are up for discussion.