### PR TITLE
Run the build on pull requests as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - 'master'
       - 'oldsite'
+  pull_request:
   schedule:
     - cron: '0 4 * * *'
   workflow_dispatch:


### PR DESCRIPTION
`deploy.sh` already has a `if [ "$github_repo" = "leanprover-community/leanprover-community.github.io" -a "$github_ref" = "refs/heads/lean4" ]; then` check that should make sure the site is only built, not deployed.