### PR TITLE
change logic for which theorems count as formalized

### DIFF
--- a/make_site.py
+++ b/make_site.py
@@ -255,6 +255,8 @@ class TheoremForWebpage:
     author: Optional[str] = None
     date: Optional[str] = None
     note: Optional[str] = None
+    # A boolean tagging theorems that have been formalized
+    formalized: bool
 
 
 @dataclass
@@ -362,7 +364,9 @@ def download_N_theorems(kind: NTheorems) -> dict:
                             # note: the `header-data.json` data file uses doc-relative links
                             docs_link='/mathlib4_docs/' + decl_info.info.docLink,
                             src_link=decl_info.info.sourceLink))
-                theorems.append(TheoremForWebpage(id, h.title, doc_decls, links, h.author, h.date, note))
+                # a theorem counts as formalized if the author field is nonempty or if doc_decls is nonempty
+                formalized = bool(h.author) or (len(doc_decls) > 0)
+                theorems.append(TheoremForWebpage(id, h.title, doc_decls, links, h.author, h.date, note, formalized))
         pkl_dump(name, theorems)
     else:
         theorems = pkl_load(name, dict())

--- a/make_site.py
+++ b/make_site.py
@@ -364,7 +364,7 @@ def download_N_theorems(kind: NTheorems) -> dict:
                             # note: the `header-data.json` data file uses doc-relative links
                             docs_link='/mathlib4_docs/' + decl_info.info.docLink,
                             src_link=decl_info.info.sourceLink))
-                # a theorem counts as formalized if the author field is nonempty or if doc_decls is nonempty
+                # A theorem counts as formalized if the author field or `doc_decls` is non-empty.
                 formalized = bool(h.author) or (len(doc_decls) > 0)
                 theorems.append(TheoremForWebpage(id, h.title, formalized, doc_decls, links, h.author, h.date, note))
         pkl_dump(name, theorems)

--- a/make_site.py
+++ b/make_site.py
@@ -247,6 +247,8 @@ class TheoremForWebpage:
     """
     id: str
     title: str
+    # A boolean tagging theorems that have been formalized
+    formalized: bool
     # The HTML source code for the generated documentation entries
     # for the declaration associated to this theorem.
     doc_decls: Optional[List[DocDecl]]
@@ -255,8 +257,6 @@ class TheoremForWebpage:
     author: Optional[str] = None
     date: Optional[str] = None
     note: Optional[str] = None
-    # A boolean tagging theorems that have been formalized
-    formalized: bool
 
 
 @dataclass
@@ -366,7 +366,7 @@ def download_N_theorems(kind: NTheorems) -> dict:
                             src_link=decl_info.info.sourceLink))
                 # a theorem counts as formalized if the author field is nonempty or if doc_decls is nonempty
                 formalized = bool(h.author) or (len(doc_decls) > 0)
-                theorems.append(TheoremForWebpage(id, h.title, doc_decls, links, h.author, h.date, note, formalized))
+                theorems.append(TheoremForWebpage(id, h.title, formalized, doc_decls, links, h.author, h.date, note))
         pkl_dump(name, theorems)
     else:
         theorems = pkl_load(name, dict())

--- a/templates/100-missing.html
+++ b/templates/100-missing.html
@@ -4,8 +4,9 @@
 {% markdown %}
 # Missing theorems from [Freek Wiedijk's](https://www.cs.ru.nl/~freek/) [list of 100 theorems](https://www.cs.ru.nl/~freek/100/)
 These theorems are not yet formalized in Lean.
+Currently there are {{hundred_theorems|rejectattr('formalized')|list|length}} of them.
 <a href="100.html">Here</a> is the list of the formalized theorems.
-{% for theorem in hundred_theorems|rejectattr('author') %}
+{% for theorem in hundred_theorems|rejectattr('formalized') %}
 * {{ theorem.id }}: {{ theorem.title }}
 {% endfor %}
 {% endmarkdown %}

--- a/templates/100.html
+++ b/templates/100.html
@@ -5,7 +5,7 @@
         <h1>100 theorems</h1>
 
         <p><a href="https://www.cs.ru.nl/~freek/">Freek Wiedijk</a> maintains <a href="https://www.cs.ru.nl/~freek/100/">a list</a> tracking progress of theorem provers in formalizing 100 classic theorems in mathematics as a way of comparing prominent theorem provers.
-        Currently {{hundred_theorems|selectattr('author')|list|length}} of them are formalized in Lean.
+        Currently {{hundred_theorems|selectattr('formalized')|list|length}} of them are formalized in Lean.
         We also have a page with the theorems from the list <a href="100-missing.html">not yet in Lean</a>.</p>
 
 	<p>

--- a/templates/100.html
+++ b/templates/100.html
@@ -18,7 +18,7 @@
 
     {% for theorem in hundred_theorems|selectattr('formalized') %}
         <h5 class="markdown-heading mt-5" id="{{ theorem.id }}">{{ theorem.id }}. {{ theorem.title }} <a class="hover-link" href="#{{ theorem.id }}">#</a></h5>
-        <p>Author{% if ' and ' in theorem.author %}s{% endif %}: {{ theorem.author }}</p>
+        {% if theorem.author %}<p>Author{% if ' and ' in theorem.author %}s{% endif %}: {{ theorem.author }}</p>{% endif %}
         {% if theorem.statement %}<p><code>{{ theorem.statement }}</code></p>{% endif %}
         {% for doc in theorem.doc_decls|default([], true) %}
         <div class="doc-stmt">{{ doc.decl_header_html }}</div>

--- a/templates/100.html
+++ b/templates/100.html
@@ -16,7 +16,7 @@
 	<a href="https://docs.github.com/en/github/managing-files-in-a-repository/editing-files-in-another-users-repository">"Editing files in another user's repository"</a>.
 	</p>
 
-    {% for theorem in hundred_theorems|selectattr('author') %}
+    {% for theorem in hundred_theorems|selectattr('formalized') %}
         <h5 class="markdown-heading mt-5" id="{{ theorem.id }}">{{ theorem.id }}. {{ theorem.title }} <a class="hover-link" href="#{{ theorem.id }}">#</a></h5>
         <p>Author{% if ' and ' in theorem.author %}s{% endif %}: {{ theorem.author }}</p>
         {% if theorem.statement %}<p><code>{{ theorem.statement }}</code></p>{% endif %}

--- a/templates/1000-missing.html
+++ b/templates/1000-missing.html
@@ -4,8 +4,9 @@
 {% markdown %}
 # Missing theorems from [Freek Wiedijk's](https://www.cs.ru.nl/~freek/) [1000+ theorems project](https://1000-plus.github.io/)
 These theorems are not yet formalized in Lean (or, these formalisations are not entered in the database yet).
+Currently there are {{hundred_theorems|rejectattr('formalized')|list|length}} of them.
 <a href="1000.html">Here</a> is the list of the formalized theorems.
-{% for theorem in thousand_theorems|rejectattr('author') %}
+{% for theorem in thousand_theorems|rejectattr('formalized') %}
 * {{ theorem.id }}: {{ theorem.title }}
 {% endfor %}
 {% endmarkdown %}

--- a/templates/1000-missing.html
+++ b/templates/1000-missing.html
@@ -4,7 +4,7 @@
 {% markdown %}
 # Missing theorems from [Freek Wiedijk's](https://www.cs.ru.nl/~freek/) [1000+ theorems project](https://1000-plus.github.io/)
 These theorems are not yet formalized in Lean (or, these formalisations are not entered in the database yet).
-Currently there are {{hundred_theorems|rejectattr('formalized')|list|length}} of them.
+Currently there are {{thousand_theorems|rejectattr('formalized')|list|length}} of them.
 <a href="1000.html">Here</a> is the list of the formalized theorems.
 {% for theorem in thousand_theorems|rejectattr('formalized') %}
 * {{ theorem.id }}: {{ theorem.title }}

--- a/templates/1000.html
+++ b/templates/1000.html
@@ -16,7 +16,7 @@
 	<a href="https://docs.github.com/en/github/managing-files-in-a-repository/editing-files-in-another-users-repository">"Editing files in another user's repository"</a>.
 	</p>
 
-    {% for theorem in thousand_theorems|selectattr('author') %}
+    {% for theorem in thousand_theorems|selectattr('formalized') %}
         <h5 class="markdown-heading mt-5" id="{{ theorem.id }}">{{ theorem.id }}: {{ theorem.title }} <a class="hover-link" href="#{{ theorem.id }}">#</a></h5>
         <p>Author{% if ' and ' in theorem.author %}s{% endif %}: {{ theorem.author }}</p>
         {% if theorem.statement %}<p><code>{{ theorem.statement }}</code></p>{% endif %}

--- a/templates/1000.html
+++ b/templates/1000.html
@@ -5,7 +5,7 @@
         <h1>1000+ theorems</h1>
 
         <p><a href="https://www.cs.ru.nl/~freek/">Freek Wiedijk</a> started the <a href="https://1000-plus.github.io/">1000+ theorems project</a> tracking progress of theorem provers in formalizing named theorems on wikipedia, as a way of comparing prominent theorem provers.
-        Currently {{thousand_theorems|selectattr('author')|list|length}} of them are formalized in Lean.
+        Currently {{thousand_theorems|selectattr('formalized')|list|length}} of them are formalized in Lean.
         We also have a page with the theorems from the list <a href="1000-missing.html">not yet in Lean</a>.</p>
 
 	<p>

--- a/templates/1000.html
+++ b/templates/1000.html
@@ -18,7 +18,7 @@
 
     {% for theorem in thousand_theorems|selectattr('formalized') %}
         <h5 class="markdown-heading mt-5" id="{{ theorem.id }}">{{ theorem.id }}: {{ theorem.title }} <a class="hover-link" href="#{{ theorem.id }}">#</a></h5>
-        <p>Author{% if ' and ' in theorem.author %}s{% endif %}: {{ theorem.author }}</p>
+        {% if theorem.author %}<p>Author{% if ' and ' in theorem.author %}s{% endif %}: {{ theorem.author }}</p>{% endif %}
         {% if theorem.statement %}<p><code>{{ theorem.statement }}</code></p>{% endif %}
         {% for doc in theorem.doc_decls|default([], true) %}
         <div class="doc-stmt">{{ doc.decl_header_html }}</div>


### PR DESCRIPTION
(and move out of templates into make_site.py)

cf. [Zulip](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/1000-plus.20theorems.20project/near/492814764)