### PR TITLE
feat: allow statements of theorems in 1000.yaml

### DIFF
--- a/make_site.py
+++ b/make_site.py
@@ -232,6 +232,7 @@ class ThousandPlusTheorem:
     # any additional notes or comments
     comment: Optional[str] = None
 
+
 @dataclass
 class TheoremForWebpage:
     """
@@ -249,8 +250,10 @@ class TheoremForWebpage:
     """
     id: str
     title: str
-    # A boolean tagging theorems that have been formalized
-    formalized: bool
+    # Whether just the theorem statement has been formalized
+    statement_formalized: bool
+    # Whether this theorem's proof has been formalized
+    proof_formalized: bool
     # The HTML source code for the generated documentation entries
     # for the declaration associated to this theorem.
     doc_decls: Optional[List[DocDecl]]
@@ -346,10 +349,13 @@ def download_N_theorems(kind: NTheorems) -> dict:
             for h in n_theorems:
                 assert not (h.decl and h.decls)
                 assert not h.statement and (h.decl or h.decls)
+                statement_formalised = False
                 if kind == NTheorems.Hundred:
                     (id, links, thms, note) = (h.number, h.links, '100 theorems', h.note)
                 else:
                     (id, links, thms, note) = (h.wikidata, {'url': h.url} if h.url else {}, '1000+ theorems', h.comment)
+                    if h.statement:
+                        statement_formalised = True
                 decls = h.decls or ([h.decl] if h.decl else []) or ([h.statement] if h.statement else [])
                 doc_decls = []
                 if decls:
@@ -367,9 +373,9 @@ def download_N_theorems(kind: NTheorems) -> dict:
                             # note: the `header-data.json` data file uses doc-relative links
                             docs_link='/mathlib4_docs/' + decl_info.info.docLink,
                             src_link=decl_info.info.sourceLink))
-                # A theorem counts as formalized if the author field or `doc_decls` is non-empty.
-                formalized = bool(h.author) or (len(doc_decls) > 0)
-                theorems.append(TheoremForWebpage(id, h.title, formalized, doc_decls, links, h.author, h.date, note))
+                # A theorem's proof's proof counts as formalized if the author field or `doc_decls` is non-empty.
+                proof_formalized = bool(h.author) or (len(doc_decls) > 0)
+                theorems.append(TheoremForWebpage(id, h.title, statement_formalised, proof_formalized, status, doc_decls, links, h.author, h.date, note))
         pkl_dump(name, theorems)
     else:
         theorems = pkl_load(name, dict())

--- a/make_site.py
+++ b/make_site.py
@@ -216,6 +216,8 @@ class ThousandPlusTheorem:
     wikidata: str
     # a human-readable title
     title: str
+    # If a theorem is merely *stated* in mathlib, the name of the declaration
+    statement: Optional[str] = None
     # if a theorem is formalised in mathlib, the archive or counterexamples,
     # the name of the corresponding declaration (optional)
     decl: Optional[str] = None
@@ -339,15 +341,16 @@ def download_N_theorems(kind: NTheorems) -> dict:
     if DOWNLOAD:
         download(f'https://leanprover-community.github.io/mathlib4_docs/{fname}', DATA/fname)
         with (DATA/fname).open('r', encoding='utf-8') as h_file:
-            n_theorems = [Type(thm,**content) for (thm,content) in yaml.safe_load(h_file).items()]
+            n_theorems = [Type(thm, **content) for (thm, content) in yaml.safe_load(h_file).items()]
             theorems = []
             for h in n_theorems:
                 assert not (h.decl and h.decls)
+                assert not h.statement and (h.decl or h.decls)
                 if kind == NTheorems.Hundred:
                     (id, links, thms, note) = (h.number, h.links, '100 theorems', h.note)
                 else:
                     (id, links, thms, note) = (h.wikidata, {'url': h.url} if h.url else {}, '1000+ theorems', h.comment)
-                decls = h.decls or ([h.decl] if h.decl else [])
+                decls = h.decls or ([h.decl] if h.decl else []) or ([h.statement] if h.statement else [])
                 doc_decls = []
                 if decls:
                     for decl in decls:

--- a/templates/100-missing.html
+++ b/templates/100-missing.html
@@ -5,6 +5,7 @@
 # Missing theorems from [Freek Wiedijk's](https://www.cs.ru.nl/~freek/) [list of 100 theorems](https://www.cs.ru.nl/~freek/100/)
 These theorems are not yet formalized in Lean.
 Currently there are {{hundred_theorems|rejectattr('proof_formalized')|list|length}} of them.
+Among these, {{hundred_theorems|rejectattr('proof_formalized')|selectattr('statement_formalized')|list|length}} have their statement formalized.
 <a href="100.html">Here</a> is the list of the formalized theorems.
 {% for theorem in hundred_theorems|rejectattr('proof_formalized') %}
 * {{ theorem.id }}: {{ theorem.title }}

--- a/templates/100-missing.html
+++ b/templates/100-missing.html
@@ -10,5 +10,19 @@ Among these, {{hundred_theorems|rejectattr('proof_formalized')|selectattr('state
 {% for theorem in hundred_theorems|rejectattr('proof_formalized') %}
 * {{ theorem.id }}: {{ theorem.title }}
 {% endfor %}
+
+The following theorem(s) have just their statement formalized. Contributions to their proofs are welcome.
+{% for theorem in thousand_theorems|selectattr('statement_formalized') %}
+    <h5 class="markdown-heading mt-5" id="{{ theorem.id }}">{{ theorem.id }}: {{ theorem.title }} <a class="hover-link" href="#{{ theorem.id }}">#</a></h5>
+    {% if theorem.author %}<p>Author{% if ' and ' in theorem.author %}s{% endif %}: {{ theorem.author }}</p>{% endif %}
+    {% if theorem.statement %}<p><code>{{ theorem.statement }}</code></p>{% endif %}
+    {% for doc in theorem.doc_decls|default([], true) %}
+    <div class="doc-stmt">{{ doc.decl_header_html }}</div>
+    <p><a href="{{ doc.docs_link }}">docs</a>, <a href="{{ doc.src_link }}">source</a></p>
+    {% endfor %}
+    {% for title, link in (theorem.links|default({}, true)).items() %}<p><a href="{{link}}">{{title}}</a></p>{% endfor %}
+    {% if theorem.note %}<p>{% markdown %}{{ theorem.note }}{% endmarkdown %}</p>{% endif %}
+{% endfor %}
+
 {% endmarkdown %}
 {% endblock %}

--- a/templates/100-missing.html
+++ b/templates/100-missing.html
@@ -4,9 +4,9 @@
 {% markdown %}
 # Missing theorems from [Freek Wiedijk's](https://www.cs.ru.nl/~freek/) [list of 100 theorems](https://www.cs.ru.nl/~freek/100/)
 These theorems are not yet formalized in Lean.
-Currently there are {{hundred_theorems|rejectattr('formalized')|list|length}} of them.
+Currently there are {{hundred_theorems|rejectattr('proof_formalized')|list|length}} of them.
 <a href="100.html">Here</a> is the list of the formalized theorems.
-{% for theorem in hundred_theorems|rejectattr('formalized') %}
+{% for theorem in hundred_theorems|rejectattr('proof_formalized') %}
 * {{ theorem.id }}: {{ theorem.title }}
 {% endfor %}
 {% endmarkdown %}

--- a/templates/100.html
+++ b/templates/100.html
@@ -2,11 +2,13 @@
 {% block title %}100 theorems in Lean{% endblock %}
 {% block content %}
 
-        <h1>100 theorems</h1>
+    <h1>100 theorems</h1>
 
-        <p><a href="https://www.cs.ru.nl/~freek/">Freek Wiedijk</a> maintains <a href="https://www.cs.ru.nl/~freek/100/">a list</a> tracking progress of theorem provers in formalizing 100 classic theorems in mathematics as a way of comparing prominent theorem provers.
-        Currently {{hundred_theorems|selectattr('proof_formalized')|list|length}} of them are formalized in Lean.
-        We also have a page with the theorems from the list <a href="100-missing.html">not yet in Lean</a>.</p>
+    <p><a href="https://www.cs.ru.nl/~freek/">Freek Wiedijk</a> maintains <a href="https://www.cs.ru.nl/~freek/100/">a list</a> tracking progress of theorem provers in formalizing 100 classic theorems in mathematics as a way of comparing prominent theorem provers.
+    Currently {{hundred_theorems|selectattr('proof_formalized')|list|length}} of them are formalized in Lean,
+    and {{hundred_theorems|rejectattr('proof_formalized')|selectattr('statement_formalized')|list|length}} additional theorem(s) have just their statement formalized in Lean.
+
+    We also have a page with the theorems from the list <a href="100-missing.html">not yet in Lean</a>.</p>
 
 	<p>
 	To make updates to this list, please <a href="contribute/index.html">make a pull request to mathlib</a>

--- a/templates/100.html
+++ b/templates/100.html
@@ -5,7 +5,7 @@
         <h1>100 theorems</h1>
 
         <p><a href="https://www.cs.ru.nl/~freek/">Freek Wiedijk</a> maintains <a href="https://www.cs.ru.nl/~freek/100/">a list</a> tracking progress of theorem provers in formalizing 100 classic theorems in mathematics as a way of comparing prominent theorem provers.
-        Currently {{hundred_theorems|selectattr('formalized')|list|length}} of them are formalized in Lean.
+        Currently {{hundred_theorems|selectattr('proof_formalized')|list|length}} of them are formalized in Lean.
         We also have a page with the theorems from the list <a href="100-missing.html">not yet in Lean</a>.</p>
 
 	<p>
@@ -16,7 +16,7 @@
 	<a href="https://docs.github.com/en/github/managing-files-in-a-repository/editing-files-in-another-users-repository">"Editing files in another user's repository"</a>.
 	</p>
 
-    {% for theorem in hundred_theorems|selectattr('formalized') %}
+    {% for theorem in hundred_theorems|selectattr('proof_formalized') %}
         <h5 class="markdown-heading mt-5" id="{{ theorem.id }}">{{ theorem.id }}. {{ theorem.title }} <a class="hover-link" href="#{{ theorem.id }}">#</a></h5>
         {% if theorem.author %}<p>Author{% if ' and ' in theorem.author %}s{% endif %}: {{ theorem.author }}</p>{% endif %}
         {% if theorem.statement %}<p><code>{{ theorem.statement }}</code></p>{% endif %}

--- a/templates/1000-missing.html
+++ b/templates/1000-missing.html
@@ -4,9 +4,10 @@
 {% markdown %}
 # Missing theorems from [Freek Wiedijk's](https://www.cs.ru.nl/~freek/) [1000+ theorems project](https://1000-plus.github.io/)
 These theorems are not yet formalized in Lean (or, these formalisations are not entered in the database yet).
-Currently there are {{thousand_theorems|rejectattr('formalized')|list|length}} of them.
+Currently there are {{thousand_theorems|rejectattr('proof_formalized')|list|length}} of them.
+Among these, {{thousand_theorems|rejectattr('proof_formalized')|selectattr('statement_formalized')|list|length}} have their statement formalised.
 <a href="1000.html">Here</a> is the list of the formalized theorems.
-{% for theorem in thousand_theorems|rejectattr('formalized') %}
+{% for theorem in thousand_theorems|rejectattr('proof_formalized') %}
 * {{ theorem.id }}: {{ theorem.title }}
 {% endfor %}
 {% endmarkdown %}

--- a/templates/1000-missing.html
+++ b/templates/1000-missing.html
@@ -10,5 +10,19 @@ Among these, {{thousand_theorems|rejectattr('proof_formalized')|selectattr('stat
 {% for theorem in thousand_theorems|rejectattr('proof_formalized') %}
 * {{ theorem.id }}: {{ theorem.title }}
 {% endfor %}
+
+The following theorem(s) have just their statement formalized. Contributions to their proofs are welcome.
+{% for theorem in thousand_theorems|selectattr('statement_formalized') %}
+    <h5 class="markdown-heading mt-5" id="{{ theorem.id }}">{{ theorem.id }}: {{ theorem.title }} <a class="hover-link" href="#{{ theorem.id }}">#</a></h5>
+    {% if theorem.author %}<p>Author{% if ' and ' in theorem.author %}s{% endif %}: {{ theorem.author }}</p>{% endif %}
+    {% if theorem.statement %}<p><code>{{ theorem.statement }}</code></p>{% endif %}
+    {% for doc in theorem.doc_decls|default([], true) %}
+    <div class="doc-stmt">{{ doc.decl_header_html }}</div>
+    <p><a href="{{ doc.docs_link }}">docs</a>, <a href="{{ doc.src_link }}">source</a></p>
+    {% endfor %}
+    {% for title, link in (theorem.links|default({}, true)).items() %}<p><a href="{{link}}">{{title}}</a></p>{% endfor %}
+    {% if theorem.note %}<p>{% markdown %}{{ theorem.note }}{% endmarkdown %}</p>{% endif %}
+{% endfor %}
+
 {% endmarkdown %}
 {% endblock %}

--- a/templates/1000-missing.html
+++ b/templates/1000-missing.html
@@ -3,9 +3,9 @@
 {% block content %}
 {% markdown %}
 # Missing theorems from [Freek Wiedijk's](https://www.cs.ru.nl/~freek/) [1000+ theorems project](https://1000-plus.github.io/)
-These theorems are not yet formalized in Lean (or, these formalisations are not entered in the database yet).
+These theorems are not yet formalized in Lean (or, these formalizations are not entered in the database yet).
 Currently there are {{thousand_theorems|rejectattr('proof_formalized')|list|length}} of them.
-Among these, {{thousand_theorems|rejectattr('proof_formalized')|selectattr('statement_formalized')|list|length}} have their statement formalised.
+Among these, {{thousand_theorems|rejectattr('proof_formalized')|selectattr('statement_formalized')|list|length}} have their statement formalized.
 <a href="1000.html">Here</a> is the list of the formalized theorems.
 {% for theorem in thousand_theorems|rejectattr('proof_formalized') %}
 * {{ theorem.id }}: {{ theorem.title }}

--- a/templates/1000.html
+++ b/templates/1000.html
@@ -29,7 +29,7 @@
         {% if theorem.note %}<p>{% markdown %}{{ theorem.note }}{% endmarkdown %}</p>{% endif %}
     {% endfor %}
 
-    The following theorems have just their statement formalised. Contributions to their proofs are welcome.
+    The following theorems have just their statement formalized. Contributions to their proofs are welcome.
     {% for theorem in thousand_theorems|selectattr('statement_formalized') %}
         <h5 class="markdown-heading mt-5" id="{{ theorem.id }}">{{ theorem.id }}: {{ theorem.title }} <a class="hover-link" href="#{{ theorem.id }}">#</a></h5>
         {% if theorem.author %}<p>Author{% if ' and ' in theorem.author %}s{% endif %}: {{ theorem.author }}</p>{% endif %}

--- a/templates/1000.html
+++ b/templates/1000.html
@@ -2,11 +2,12 @@
 {% block title %}1000+ theorems in Lean{% endblock %}
 {% block content %}
 
-        <h1>1000+ theorems</h1>
+    <h1>1000+ theorems</h1>
 
-        <p><a href="https://www.cs.ru.nl/~freek/">Freek Wiedijk</a> started the <a href="https://1000-plus.github.io/">1000+ theorems project</a> tracking progress of theorem provers in formalizing named theorems on wikipedia, as a way of comparing prominent theorem provers.
-        Currently {{thousand_theorems|selectattr('formalized')|list|length}} of them are formalized in Lean.
-        We also have a page with the theorems from the list <a href="1000-missing.html">not yet in Lean</a>.</p>
+    <p><a href="https://www.cs.ru.nl/~freek/">Freek Wiedijk</a> started the <a href="https://1000-plus.github.io/">1000+ theorems project</a> tracking progress of theorem provers in formalizing named theorems on wikipedia, as a way of comparing prominent theorem provers.
+    Currently {{thousand_theorems|selectattr('proof_formalized')|list|length}} of them are formalized in Lean,
+    and {{thousand_theorems|selectattr('statement_formalized')|list|length}} additional theorem(s) have just their statement formalized in Lean.
+    We also have a page with the theorems from the list <a href="1000-missing.html">not yet in Lean</a>.</p>
 
 	<p>
 	To make updates to this list, please <a href="contribute/index.html">make a pull request to mathlib</a>
@@ -16,7 +17,20 @@
 	<a href="https://docs.github.com/en/github/managing-files-in-a-repository/editing-files-in-another-users-repository">"Editing files in another user's repository"</a>.
 	</p>
 
-    {% for theorem in thousand_theorems|selectattr('formalized') %}
+    {% for theorem in thousand_theorems|selectattr('proof_formalized') %}
+        <h5 class="markdown-heading mt-5" id="{{ theorem.id }}">{{ theorem.id }}: {{ theorem.title }} <a class="hover-link" href="#{{ theorem.id }}">#</a></h5>
+        {% if theorem.author %}<p>Author{% if ' and ' in theorem.author %}s{% endif %}: {{ theorem.author }}</p>{% endif %}
+        {% if theorem.statement %}<p><code>{{ theorem.statement }}</code></p>{% endif %}
+        {% for doc in theorem.doc_decls|default([], true) %}
+        <div class="doc-stmt">{{ doc.decl_header_html }}</div>
+        <p><a href="{{ doc.docs_link }}">docs</a>, <a href="{{ doc.src_link }}">source</a></p>
+        {% endfor %}
+        {% for title, link in (theorem.links|default({}, true)).items() %}<p><a href="{{link}}">{{title}}</a></p>{% endfor %}
+        {% if theorem.note %}<p>{% markdown %}{{ theorem.note }}{% endmarkdown %}</p>{% endif %}
+    {% endfor %}
+
+    The following theorems have just their statement formalised. Contributions to their proofs are welcome.
+    {% for theorem in thousand_theorems|selectattr('statement_formalized') %}
         <h5 class="markdown-heading mt-5" id="{{ theorem.id }}">{{ theorem.id }}: {{ theorem.title }} <a class="hover-link" href="#{{ theorem.id }}">#</a></h5>
         {% if theorem.author %}<p>Author{% if ' and ' in theorem.author %}s{% endif %}: {{ theorem.author }}</p>{% endif %}
         {% if theorem.statement %}<p><code>{{ theorem.statement }}</code></p>{% endif %}


### PR DESCRIPTION
And display these on the generated webpage as well.

I don't expect the list of theorems with just a statement to grow large, but for some results, this could be useful.
Accompanies https://github.com/leanprover-community/mathlib4/pull/20637; it's better to merge this PR first.