### PR TITLE
feat: add link tactic list

### DIFF
--- a/data/menus.yaml
+++ b/data/menus.yaml
@@ -21,6 +21,7 @@
     - Learning resources (start here): learn.html
     - API documentation: https://leanprover-community.github.io/mathlib4_docs
     - Declaration search (Loogle): https://loogle.lean-lang.org/
+    - Tactic list: https://leanprover-community.github.io/mathlib-manual/html-multi/
     - Calc mode: extras/calc.html
     - Conv mode: extras/conv.html
     - Simplifier: extras/simp.html


### PR DESCRIPTION
Add a link to the Verso project [Mathlib Manual](https://leanprover-community.github.io/mathlib-manual/html-multi/), currently featuring an auto-generated list of all tactics, along with some curated tactic lists.