### PR TITLE
feat: add language reference to documentation overview

### DIFF
--- a/data/menus.yaml
+++ b/data/menus.yaml
@@ -21,6 +21,7 @@
     - Learning resources (start here): learn.html
     - API documentation: https://leanprover-community.github.io/mathlib4_docs
     - Declaration search (Loogle): https://loogle.lean-lang.org/
+    - Language reference: https://lean-lang.org/doc/reference/latest/
     - Tactic list: https://leanprover-community.github.io/mathlib-manual/html-multi/
     - Calc mode: extras/calc.html
     - Conv mode: extras/conv.html


### PR DESCRIPTION
I think it might help users find the reference manual if it's included in the overview of documentation on this site.