### PR TITLE
use mailmap data for contributor count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ bootstrap-*
 export_db.json.gz
 data/100.yaml
 data/1000.yaml
+data/contributor-count
 data/overview.yaml
 data/undergrad.yaml
 data/project_history.yaml

--- a/make_site.py
+++ b/make_site.py
@@ -562,7 +562,16 @@ else:
     projects = pkl_load('projects', [])
 
 if DOWNLOAD:
-    num_contrib = github.get_repo('leanprover-community/mathlib4').get_contributors(anon=True).totalCount
+    # We used to use this count but it didn't include mathlib3 contributors
+    # num_contrib = github.get_repo('leanprover-community/mathlib4').get_contributors(anon=True).totalCount
+    # The `contributor-count` file is uploaded by the github workflow in the mathlib_stats repo:
+    download(
+        'https://leanprover-community.github.io/mathlib_stats/contributor-count',
+        DATA/'contributor-count')
+    with (DATA/'contributor-count').open('r', encoding='utf-8') as h_file:
+        # we could just display the file contents directly,
+        # but better to try to convert to a number and error out if something unexpected is there
+        num_contrib = int(h_file.readline().strip())
     pkl_dump('num_contrib', num_contrib)
 else:
     num_contrib = pkl_load('num_contrib', 0)


### PR DESCRIPTION
Per discussion in maintainer's stream. Already tested locally.

See also https://github.com/leanprover-community/mathlib_stats/pull/12, which is now uploading a text file with the number of contributors [here](https://leanprover-community.github.io/mathlib_stats/contributor-count).

(For those with access to the `mathlib-mailmap` repo, [here's](https://github.com/leanprover-community/mathlib-mailmap/blob/7775b1a2644ac5e8cb4749f7926875b849ce6b7c/count) the script that generates the count of contributors).