### PR TITLE
Direct the user wanting to install Lean to the official website

### DIFF
--- a/templates/get_started.md
+++ b/templates/get_started.md
@@ -1,19 +1,48 @@
 # Get started with Lean
 
-Please follow the [instructions in the official Lean manual](https://docs.lean-lang.org/lean4/doc/quickstart.html) to install Lean.
+There are two ways for you to start interacting with Lean. Installing it on your own computer
+will give you the most satisfactory experience. However some Lean projects offer ways of
+interacting with them via the cloud, which requires no local installation.
 
-After this installation procedure, it is crucial to read how to start or
-get a [Lean project](install/project.html). And of course you'll
-probably want to [learn Lean](learn.html)!
+## Without a local installation
 
 If you only want to try Lean without installing it, you can try running it in
 the cloud using Gitpod or GitHub codespaces. For instance you can read
-the book [Mathematics in Lean](https://leanprover-community.github.io/mathematics_in_lean/) while doing the exercises [on Gitpod](https://gitpod.io/#/https://github.com/leanprover-community/mathematics_in_lean). Note this Gitpod option requires you to create an account somewhere.
+the book [Mathematics in Lean](https://leanprover-community.github.io/mathematics_in_lean/) while 
+doing the exercises [on Gitpod](https://gitpod.io/#/https://github.com/leanprover-community/mathematics_in_lean). 
+Note this Gitpod option requires you to create an account somewhere. Note also that 
+Gitpod is being deprecated in April 2025.
 
-If you have issues installing Lean using the official instructions, you can also follow the following legacy instructions:
+## Installing Lean and creating a project
+
+The important thing to know about a local installation is that it is a two step process. 
+First you need to install the software. But this is not enough; to run Lean on a file,
+the file must be part of a Lean project. 
+
+Once you have installed Lean, you can either install a Lean project from the internet
+(for example the [Mathematics in Lean](https://leanprover-community.github.io/mathematics_in_lean/)
+project) or you can create your own project.
+
+The recommended way to install Lean and to get working with a project is to follow the
+[instructions in the official Lean manual](https://docs.lean-lang.org/lean4/doc/quickstart.html).
+The manual explains a simple point-and-click method for both installing Lean, and creating
+or downloading a project.
+
+After you have followed these instructions, you'll probably want to [learn Lean](learn.html)!
+
+## Legacy / command line
+
+The community used to maintain its own installation instructions. These contain more
+low-level instructions on how to install Lean and to create projects. They may
+be out of date.
+
+### Legacy installation instructions
 
 * [Debian/Ubuntu](install/debian.html)
 * [Other linux](install/linux.html)
 * [MacOS](install/macos.html)
 * [Windows](install/windows.html)
 
+### Legacy project installation instructions
+
+* [Creating a project](install/project.html)

--- a/templates/get_started.md
+++ b/templates/get_started.md
@@ -30,7 +30,7 @@ or downloading a project.
 
 After you have followed these instructions, you'll probably want to [learn Lean](learn.html)!
 
-## Legacy / command line
+## Command line
 
 The community used to maintain its own installation instructions. These contain more
 low-level instructions on how to install Lean and to create projects. They may

--- a/templates/install/debian.md
+++ b/templates/install/debian.md
@@ -1,5 +1,11 @@
 # How to install Lean 4 on Debian/Ubuntu
 
+Note that these are legacy instructions provided by the community. The recommended
+way to install Lean and to create a project is to follow the instructions in
+[the official Lean documentation](https://docs.lean-lang.org/lean4/doc/quickstart.html).
+
+## Legacy instructions
+
 This document explains how to get started with Lean and mathlib if you
 are using a Linux distribution derived from Debian (Debian itself,
 Ubuntu, LMDE,...).

--- a/templates/install/debian_details.md
+++ b/templates/install/debian_details.md
@@ -1,5 +1,11 @@
 # Controlled installation of Lean 4 on Debian/Ubuntu
 
+Note that these are legacy instructions provided by the community. The recommended
+way to install Lean and to create a project is to follow the instructions in
+[the official Lean documentation](https://docs.lean-lang.org/lean4/doc/quickstart.html).
+
+## Legacy instructions
+
 This document explains a more controlled installation procedure
 for Lean 4 and mathlib on Linux distributions derived from Debian (Debian
 itself, Ubuntu, LMDE,...). There is a quicker way described in the main

--- a/templates/install/linux.md
+++ b/templates/install/linux.md
@@ -1,5 +1,11 @@
 # Installing Lean 4 on Linux
 
+Note that these are legacy instructions provided by the community. The recommended
+way to install Lean and to create a project is to follow the instructions in
+[the official Lean documentation](https://docs.lean-lang.org/lean4/doc/quickstart.html).
+
+## Legacy instructions
+
 This document explains how to get started with Lean and mathlib on a generic Linux distribution (there is a [specific page](debian.html) for Debian and derived distributions such as Ubuntu).
 
 All commands below should be typed inside a terminal.

--- a/templates/install/macos.md
+++ b/templates/install/macos.md
@@ -1,5 +1,11 @@
 # How to install Lean 4 on MacOS
 
+Note that these are legacy instructions provided by the community. The recommended
+way to install Lean and to create a project is to follow the instructions in
+[the official Lean documentation](https://docs.lean-lang.org/lean4/doc/quickstart.html).
+
+## Legacy instructions
+
 This document explains how to get started with Lean 4 if you
 are using MacOS.
 

--- a/templates/install/macos_details.md
+++ b/templates/install/macos_details.md
@@ -1,5 +1,11 @@
 # Controlled installation of Lean 4 on MacOS
 
+Note that these are legacy instructions provided by the community. The recommended
+way to install Lean and to create a project is to follow the instructions in
+[the official Lean documentation](https://docs.lean-lang.org/lean4/doc/quickstart.html).
+
+## Legacy instructions
+
 This document explains a more controlled installation procedure for Lean on MacOS. There is a quicker way described in the main
 [install page](macos.html) but it requires more trust.
 

--- a/templates/install/project.md
+++ b/templates/install/project.md
@@ -1,14 +1,29 @@
 # Lean projects
 
+After you have installed Lean, to use it you *must* create or download a Lean project.
+The recommended way to create or install a project is within Visual Studio Code (VS Code).
+Within VS Code, click on the `∀` symbol in the top right (which should be visible if
+Lean is installed) and either select "New Project" or "Open Project". 
+
+If you have not yet installed Lean, then the recommended way is to follow the instructions in
+[the official Lean documentation](https://docs.lean-lang.org/lean4/doc/quickstart.html).
+
+## Why a project?
+
 In general, if you just open a single `.lean` file in your text editor
-and try to compile it, you'll get a bunch of confusing errors.
+and try to compile it with Lean, you'll get a bunch of confusing errors.
 Every non-trivial piece of Lean code needs to live inside a *Lean project*
 (sometimes also called a Lean package).
 A "Lean project" is more than just a folder that you've named "My Lean stuff".
 Rather, it's a folder containing some very specific things:
 in particular, a *git repository* and a file
-`lakefile.lean` that gathers information about dependencies of the
+`lakefile.lean` or `lakefile.toml` that gathers information about dependencies of the
 project, including for instance the version of Lean that should be used.
+
+## Legacy instructions
+
+These legacy instructions give a command-line explanation of how to install a project
+manually.
 
 If you're interested in contributing to mathlib you only need to set up
 a Lean project once, which you can use for all your contributions —
@@ -66,7 +81,7 @@ commands should be typed in a terminal.
   you may need to first type `source ~/.profile` or `source ~/.bash_profile`.
 The keyword `math` at the end of this command adds `mathlib4` to the dependencies of your project, so that you can use `import Mathlib` in your project files.
 
-* Go inside the `my_project` folder and type `lake update` and then `mkdir MyProject`.
+* Go inside the `my_project` folder and type `lake update`.
   * Windows users seeing a `curl: (35) schannel: next InitializeSecurityContext failed` error should read [this note](#troubleshooting).
 
 * Launch VS Code, either through your application menu or by typing

--- a/templates/install/windows.md
+++ b/templates/install/windows.md
@@ -1,5 +1,11 @@
 # Installing Lean 4 on Windows
 
+Note that these are legacy instructions provided by the community. The recommended
+way to install Lean and to create a project is to follow the instructions in
+[the official Lean documentation](https://docs.lean-lang.org/lean4/doc/quickstart.html).
+
+## Legacy instructions
+
 This document explains how to get started with Lean 4 and mathlib.
 
 If you get stuck, please come to [the chat room](https://leanprover.zulipchat.com/) to ask for


### PR DESCRIPTION
I am extremely fond of the community installation pages. For years they have helped me get new users up and running, on all platforms. The pages were written back in the Lean 3 days when there was very little official support for this sort of thing, and the community web pages were playing a key role in the installation and onboarding process. 

But things move on. I recently got a new laptop and I installed Lean by following the instructions on the lean-lang website; it was completely pain-free and I never even had to open a terminal. My impression from the undergrad maths community is that this is what most people want. I think that nowadays we should be pointing new users to the official installation process rather than our detailed command-line explanations.

There will always be some people out there who will e.g. refuse to use VS Code or will want to see all the details of what is going on and actually *want* to use the command line, and for those people our pages still play an important role. But now the official web pages offer a very streamlined approach, I think it's time to start pointing people there.