### PR TITLE
fix(naming): use inline equation

### DIFF
--- a/templates/contribute/naming.md
+++ b/templates/contribute/naming.md
@@ -5,7 +5,7 @@ This guide is written for Lean 4.
 ## File names
 
 `.lean` files in mathlib should generally be named in `UpperCamelCase`.
-A (very rare) exception are files named after some specifically lower-cased object, e.g. `lp.lean` for a file specifically about the space $$\ell_p$$ (and not $$L^p$$).
+A (very rare) exception are files named after some specifically lower-cased object, e.g. `lp.lean` for a file specifically about the space $\ell_p$ (and not $L^p$).
 Such exceptions should be discussed on Zulip first.
 
 ## General conventions


### PR DESCRIPTION
Fixes an oversight in #624.

The current page looks like this, which is definitely not intended.
![Bildschirmfoto vom 2025-05-09 12-23-12](https://github.com/user-attachments/assets/27f25723-6c70-4802-9a20-cfbab663f1f2)
