### PR TITLE
feat: add a sidebar entry linking to the community guidelines

### DIFF
--- a/data/menus.yaml
+++ b/data/menus.yaml
@@ -4,6 +4,7 @@
     - GitHub: https://github.com/leanprover-community/mathlib4
     - Blog: blog
     - Community information: meet.html
+    - Community guidelines: meet.html#community-guidelines
     - Teams: teams.html
     - Papers about Lean: papers.html
     - Projects using Lean: lean_projects.html


### PR DESCRIPTION
These ought to be augmented with a section on AI usage and spam (as was posted on zulip); this can happen in a follow-up PR.

-------

Note: I am not sure if linking to a subsection of a page actually works this way. Testing welcome (last time I tried to set up a local testing environments, things failed miserably, so I cannot do so myself).