### PR TITLE
feat: add recent clarification to community guidelines

### DIFF
--- a/data/community.md
+++ b/data/community.md
@@ -83,6 +83,10 @@ These guidelines apply to the
 [Lean Zulip chat](https://leanprover.zulipchat.com/)
 and the [leanprover-community GitHub organization](https://github.com/leanprover-community/).
 
+To clarify the above: actions that can result in suspension or banning from the Lean community Zulip include harassment, discriminatory or disrespectful behavior, sustained off-topic or disruptive posts, repeated low effort posts, use of the community to complete coursework or work tasks, use of sock-puppet accounts, significant use of AI without attribution, DM spam, and ignoring moderator guidance. This list is not exhaustive and the maintainers retain broad discretion in user moderation.
+
+Repeated violations will result in temporary suspensions, which will increase in length if the behavior continues. Egregious individual incidents will result in bans.
+
 The [code of conduct team](/teams/coc.html) serves as first point of contact
 for reporting any concerns.
 We also provide an [anonymous form](https://docs.google.com/forms/d/e/1FAIpQLSdEjlFqJQV65F-yzRHl-lyWAt7TSUW1axPiQK3RyV67iu1h6Q/viewform)


### PR DESCRIPTION
Clarify the community guidelines by including the recent annoucnement [on zulip](https://leanprover.zulipchat.com/#narrow/channel/113486-announce/topic/Community.20Policies/near/514574311) in the written text. (This was always implicit policy, but it helps to make it more explicit.)

Specify some further examples of unwelcome behaviour that is disrespectful or disruptive, including using the community to complete your coursework, use of sock puppets and AI abuse.
There may be further clarifications in the future, but the above is already part of the maintainers' consensus.