### PR TITLE
feat: describe how to order `le`/`lt` and `ge`/`gt`

### DIFF
--- a/templates/contribute/naming.md
+++ b/templates/contribute/naming.md
@@ -144,14 +144,14 @@ The symbols `≤` and `<` have a special naming convention.
 In mathlib, we almost always use `≤` and `<` instead of `≥` and `>`, so we can use both `le`/`lt` and `ge`/`gt` for naming `≤` and `<`.
 There are a few reasons to use `ge`/`gt`:
 
-1. We use `ge`/`gt` if the arguments to `≤` or `<` appear in different orders. We use `le`/`lt` for the first occurrence of `≤`/`<` in the theorem statement, and then `ge`/`gt` indicates that the arguments are swapped.
+1. We use `ge`/`gt` if the arguments to `≤` or `<` appear in different orders. We use `le`/`lt` for the first occurrence of `≤`/`<` in the theorem name, and then `ge`/`gt` indicates that the arguments are swapped.
 2. We use `ge`/`gt` to match the argument order of another relation, such as `=` or `≠`.
 3. We use `ge`/`gt` to describe the `≤` or `<` relation with its arguments swapped.
 4. We use `ge`/`gt` if the second argument to `≤` or `<` is 'more variable'.
 ```lean
 -- follows rule 1
 theorem lt_iff_le_not_ge [Preorder α] {a b : α} : a < b ↔ a ≤ b ∧ ¬b ≤ a := sorry
-theorem not_ge_of_lt [Preorder α] {a b : α} (h : a < b) : ¬b ≤ a := sorry
+theorem not_le_of_gt [Preorder α] {a b : α} (h : a < b) : ¬b ≤ a := sorry
 theorem LT.lt.not_ge [Preorder α] {a b : α} (h : a < b) : ¬b ≤ a := sorry
 
 -- follows rule 2

--- a/templates/contribute/naming.md
+++ b/templates/contribute/naming.md
@@ -144,7 +144,9 @@ The symbols `≤` and `<` have a special naming convention.
 In mathlib, we almost always use `≤` and `<` instead of `≥` and `>`, so we can use both `le`/`lt` and `ge`/`gt` for naming `≤` and `<`.
 There are a few reasons to use `ge`/`gt`:
 
-1. We use `ge`/`gt` if the arguments to `≤` or `<` appear in different orders. We use `le`/`lt` for the first occurrence of `≤`/`<` in the theorem name, and then `ge`/`gt` indicates that the arguments are swapped.
+1. We use `ge`/`gt` if the arguments to `≤` or `<` appear in different orders.
+  We use `le`/`lt` for the first occurrence of `≤`/`<` in the theorem name,
+  and then `ge`/`gt` indicates that the arguments are swapped.
 2. We use `ge`/`gt` to match the argument order of another relation, such as `=` or `≠`.
 3. We use `ge`/`gt` to describe the `≤` or `<` relation with its arguments swapped.
 4. We use `ge`/`gt` if the second argument to `≤` or `<` is 'more variable'.

--- a/templates/contribute/naming.md
+++ b/templates/contribute/naming.md
@@ -144,13 +144,14 @@ The symbols `≤` and `<` have a special naming convention.
 In mathlib, we almost always use `≤` and `<` instead of `≥` and `>`, so we can use both `le`/`lt` and `ge`/`gt` for naming `≤` and `<`.
 There are a few reasons to use `ge`/`gt`:
 
-1. We use `ge`/`gt` if the arguments to `≤` or `<` appear in different orders. Then `ge`/`gt` indicates that the arguments are swapped.
+1. We use `ge`/`gt` if the arguments to `≤` or `<` appear in different orders. We use `le`/`lt` for the first occurrence of `≤`/`<` in the theorem statement, and then `ge`/`gt` indicates that the arguments are swapped.
 2. We use `ge`/`gt` to match the argument order of another relation, such as `=` or `≠`.
 3. We use `ge`/`gt` to describe the `≤` or `<` relation with its arguments swapped.
 4. We use `ge`/`gt` if the second argument to `≤` or `<` is 'more variable'.
 ```lean
 -- follows rule 1
 theorem lt_iff_le_not_ge [Preorder α] {a b : α} : a < b ↔ a ≤ b ∧ ¬b ≤ a := sorry
+theorem not_ge_of_lt [Preorder α] {a b : α} (h : a < b) : ¬b ≤ a := sorry
 theorem LT.lt.not_ge [Preorder α] {a b : α} (h : a < b) : ¬b ≤ a := sorry
 
 -- follows rule 2


### PR DESCRIPTION
Clarify a detail of the `≤ `/`<` naming convention.