### PR TITLE
feat: update contribute page to use fork-based workflow

### DIFF
--- a/templates/contribute/index.md
+++ b/templates/contribute/index.md
@@ -19,27 +19,23 @@ The `master` branch is the "production" version of mathlib.
 It is essential that everything in the master branch compiles without errors, and there are no `sorry`s.
 To ensure this, we only commit changes to `master` that have passed automated Continuous Integration ("CI") tests, and have been approved by mathlib maintainers.
 
-While you're working on a new contribution to `mathlib`, you should do this on a different branch.
-It's okay to do this in your own fork of the `mathlib` repository.
+While you're working on a new contribution to `mathlib`, you should do this on a different branch in your own fork of the `mathlib` repository.
 
-Eventually, to make a pull request, you'll need to migrate your work to a branch of the main mathlib repository,
-as our CI works better this way.
-It's polite to prefix the branch name with your github username, so it's easier for us to clean up clutter.
-To work in the main repository, you can introduce yourself on Zulip and ask for write access to non-`master` branches of the mathlib repository.
-Either [make your own thread](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members) to introduce yourself, or ask for access in
+To make a pull request, you'll work from your fork and open a PR to the main mathlib repository.
+We encourage you to introduce yourself on Zulip when you start contributing.
+Either [make your own thread](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members) to introduce yourself, or say hello in
 [this topic](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/github.20permission).
-Please include your GitHub username in your request and add this username to your Zulip profile, using [the personal settings panel](https://leanprover.zulipchat.com/#settings/profile).
+Please include your GitHub username in your Zulip profile, using [the personal settings panel](https://leanprover.zulipchat.com/#settings/profile).
 We also strongly encourage setting your display name on Zulip to be your real name.
 
 Typical workflow:
-* To get started, you'll need a local copy of mathlib.
-* If you've asked for write access (recommended above), you can just use <https://github.com/leanprover-community/mathlib4>.
-  Otherwise, you'll need to go to https://github.com/leanprover-community/mathlib4 and click "Fork" in the top right,
+* To get started, you'll need your own fork of mathlib.
+* Go to https://github.com/leanprover-community/mathlib4 and click "Fork" in the top right,
   to make your own fork of the repository.
   Your fork is at [https://github.com/USER/mathlib4](https://github.com/USER/mathlib4).
-* Now make a local clone of the repository.
+* Now make a local clone of your fork.
   ```
-  git clone https://github.com/leanprover-community/mathlib4.git
+  git clone https://github.com/USER/mathlib4.git
   cd mathlib4
   lake exe cache get
   ```
@@ -48,8 +44,6 @@ Typical workflow:
   ```
   git switch -c my_new_branch   # This creates a new branch and switches to it
   ```
-  If you've asked for write access you can push your new branch to mathlib which
-  comes with some advantages (see below).
 * Sometimes you may not want to create a new branch, but instead work on a branch
   that someone else created, or you created from a different computer.
   In that case you need to use `git switch their_new_branch` (note there is no `-c` here).
@@ -67,10 +61,9 @@ It's also okay to let our central CI servers do this for you by pushing your cha
   ```
   git push --set-upstream origin my_new_branch
   ```
-* If you're working on the main `mathlib` repository rather than your own fork,
-  continuous integration will automatically kick in at this point.
-  You can view the output by visiting
-  https://github.com/leanprover-community/mathlib4/tree/my_new_branch
+* After pushing to your fork, continuous integration will automatically kick in.
+  You can view the output by visiting your fork at
+  https://github.com/USER/mathlib4/tree/my_new_branch
   (There will be a green tick on the line describing the most recent commit if everything works,
   otherwise a yellow circle if CI is still working, or a red cross if something went wrong.
   Click on the red cross to see details.)
@@ -82,10 +75,7 @@ It's also okay to let our central CI servers do this for you by pushing your cha
 
 Once you're happy with your local changes, it's time to make a pull request.
 
-* If you haven't already asked for write access to non-master branches of the mathlib repository,
-please come to https://leanprover.zulipchat.com/, introduce yourself, and ask for this permission.
-
-* Push your changes to a branch on the main repository, if they weren't already there.
+* Make sure your changes are pushed to a branch on your fork.
 
 * If you've made a lot of changes/additions, try to make many PRs containing small, self-contained pieces; in general, the smaller the better!
   This helps you get feedback as you go along, and it is much easier to review.


### PR DESCRIPTION
Change contribution instructions from requesting write access to main repository to using fork-based workflow for pull requests.

Co-Authored-By: Claude <noreply@anthropic.com>
