### PR TITLE
fix: clarify reason rw can fail under binders

### DIFF
--- a/templates/extras/pitfalls.md
+++ b/templates/extras/pitfalls.md
@@ -146,7 +146,7 @@ example (s : Finset Nat) : ∑ i ∈ s, (0 + i ^ 2) = ∑ i ∈ s, i ^ 2 := by
   ⊢ ∑ i ∈ s, (0 + i ^ 2) = ∑ i ∈ s, i ^ 2
   -/
 ```
-This is because `∑ i ∈ s, (0 + i ^ 2)` is shorthand for `Finset.sum s (fun i ↦ 0 + i ^ 2)`, and `rw` is unable to look into the `fun` expression.
+This is because `∑ i ∈ s, (0 + i ^ 2)` is shorthand for `Finset.sum s (fun i ↦ 0 + i ^ 2)`, and `rw` sometimes fails to rewrite inside `fun` expressions because it cannot rewrite subexpressions like `0 + i ^ 2` that contain bound variables.
 
 In this case, you can use `simp_rw [Nat.zero_add]` to perform the rewrite, but in some cases you might have to make a precise rewrite using [conversion mode](https://leanprover.github.io/theorem_proving_in_lean4/conv.html):
 ```lean


### PR DESCRIPTION
Kyle Miller pointed out that what is in the pitfalls document right now is actually wrong:
https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/Documenting.20lean.20pitfalls.3A.20feedback.20requested/near/525119643