### PR TITLE
1000.html: link IDs for unproved theorems to their wikidata page

### DIFF
--- a/templates/1000.html
+++ b/templates/1000.html
@@ -35,7 +35,11 @@
 
     The following theorems have just their statement formalized. Contributions to their proofs are welcome.
     {% for theorem in thousand_theorems|selectattr('statement_formalized') %}
-        <h5 class="markdown-heading mt-5" id="{{ theorem.id }}">{{ theorem.id }}: {{ theorem.title }} <a class="hover-link" href="#{{ theorem.id }}">#</a></h5>
+        <h5 class="markdown-heading mt-5" id="{{ theorem.id }}">
+            <a href="https://www.wikidata.org/wiki/{{ theorem.id }}">{{ theorem.id }}:</a>
+            {{ theorem.title }}
+            <a class="hover-link" href="#{{ theorem.id }}">#</a>
+        </h5>
         {% if theorem.authors %}<p>Author{% if ' and ' in theorem.authors %}s{% endif %}: {{ theorem.authors }}</p>{% endif %}
         {% if theorem.statement %}<p><code>{{ theorem.statement }}</code></p>{% endif %}
         {% for doc in theorem.doc_decls|default([], true) %}


### PR DESCRIPTION
Not sure why I missed this in #576.