### PR TITLE
chore: change installation side menu to make more sense

### DIFF
--- a/data/menus.yaml
+++ b/data/menus.yaml
@@ -11,10 +11,10 @@
     - Teaching using Lean: teaching/index.html
     - Events: events.html
 
-- title: Installation
+- title: Use Lean
   items:
-    - Get started: get_started.html
     - Online version (no installation): https://live.lean-lang.org/
+    - Set up Lean: get_started.html
     - Using Lake (build system): install/project.html
 
 - title: Documentation

--- a/templates/get_started.md
+++ b/templates/get_started.md
@@ -1,4 +1,4 @@
-# Get started with Lean
+# Set up Lean
 
 There are two ways for you to start interacting with Lean. Installing it on your own computer
 will give you the most satisfactory experience. However some Lean projects offer ways of


### PR DESCRIPTION
In [this](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/Mathlib.2Edmg.20installation.3F/near/525533445) Zulip thread, Alex Kantorovich raises the issue that the installation header on the main page is somewhat unclear.

* Most glaringly, there is a a subheading under "installation" which says (no installation).
* The "Getting Started" entry actually has installation instructions, but only in the second paragraph, and it is unclear whether "Getting Started" will lead to installation instructions or a generic tutorial.

This PR proposes:

* Renaming the heading from "Installation" to "Use Lean" which is maybe a more accurate description of what the links in this subheading help you do.
* Renaming the "Getting Started" heading and file to "Set up Lean", which is more appropriate, because these instructions don't refer to learning Lean in general but to setting up an environment in particular.