### PR TITLE
Comments and labels

### DIFF
--- a/templates/contribute/index.md
+++ b/templates/contribute/index.md
@@ -103,7 +103,8 @@ The review queue is controlled by GitHub "labels".
 On the main page for a PR, on the right-hand side,
 there should be a sidebar with panels "reviewers", "assignees", "labels", etc.
 Click on the "labels" header to add or remove labels from the current project.
-(Labels can only be edited by "GitHub collaborators", which is approximately the same as "people who have write access".) Anyone can edit the labels by writing the following commands in a comment on the PR (each on its own line):
+Labels can only be edited directly by "GitHub collaborators", which is approximately the same as "people who have write access".
+However, anyone can add/remove the labels below by writing the following commands in a comment on the PR (each on its own line):
 - `awaiting-author` will add the **"awaiting-author"** label
 - `-awaiting-author` will remove the **"awaiting-author"** label
 - `WIP` will add the **"WIP"** label


### PR DESCRIPTION
The relevant PR is [mathlib#26456](https://github.com/leanprover-community/mathlib4/pull/26456), which added this automation.

[#mathlib4 > PR labels as a new contributor @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/PR.20labels.20as.20a.20new.20contributor/near/525821821)