### PR TITLE
chore: add concurrency handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,13 @@ on:
     - cron: '0 4 * * *'
   workflow_dispatch:
 
+concurrency:
+  # label each workflow run; only the latest with each label will run
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # if there is a run in progress with the same label, the next new run will be queued
+  # and new runs after that will cancel pending runs
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build HTML


### PR DESCRIPTION
The deploy often fails when we push commits too quickly one after another; this should alleviate that.