### PR TITLE
add `ci` to list of allowed commit types

### DIFF
--- a/templates/contribute/commit.md
+++ b/templates/contribute/commit.md
@@ -28,6 +28,7 @@ Note: "Title:" and "Description:" do not actually appear
  - test (when adding missing tests)
  - chore (maintain)
  - perf (performance improvement, optimization, ...)
+ - ci (for changes to github workflows, other automation)
 
 `<optional-scope>` is a name of module or a directory which contains changed modules.
 This is not necessary to include, but may be useful if the `<subject>` is insufficient.


### PR DESCRIPTION
We've already been using this for a while, so we should explicitly list it here.

cf. https://github.com/leanprover-community/mathlib4/pull/29512#discussion_r2343433566