### PR TITLE
Update courses.yaml

### DIFF
--- a/data/courses.yaml
+++ b/data/courses.yaml
@@ -17,6 +17,17 @@
 # a general subject (`mathematics`, `logic`, `computer science`).
 #
 # This list is not ordered. Add new entries wherever you want.
+- name: "Logic II : Computability, Set Theory, and Model Theory"
+  instructor: Sina Hazratpour
+  institution: Stockholm University
+  year: 2025
+  lean_version: 4
+  summary: >
+    This is an upper level undergraduate/graduate course divided into two parts: The first part covers computability and incompleteness, and the second part covers set theory and model theory. Lean is used as a digital diary for the first part of the course. The companion Lean code contains detailed definitions of the main concepts of the lectures, some basic examples and computations, and verified proofs of some of main theorems of computability and incompleteness. 
+  website: https://sinhp.github.io/teaching/2025-logic2-stockholm/
+  repo: https://github.com/sinhp/CompLean/
+  tags : ['logic', 'mathematics', 'advanced']
+  year: 2025
 - name: "Introduction to Formal Theorem Proving in Lean"
   instructor: Wuyang Chen
   institution: Simon Fraser University


### PR DESCRIPTION
adding ""Logic II : Computability, Set Theory, and Model Theory" at Stockholm. 