### PR TITLE
Add a meetup with presentations about local proof assistant users in Ghent, Belgium (Oct 25)

### DIFF
--- a/data/events.yaml
+++ b/data/events.yaml
@@ -1,3 +1,10 @@
+- title: Proof assistant users meetup in Ghent
+  url: https://www.meetup.com/nl-NL/sysghent/events/311198787
+  start_date: October 27 2025
+  end_date: October 27 2025
+  location: Ghent, Belgium
+  type: workshop
+
 - title: Lean for the Curious Mathematician 2026 (Italy)
   url: https://leanprover.zulipchat.com/#narrow/channel/113486-announce/topic/Lean.20for.20the.20Curious.20Mathematician.202026/with/523718160
   start_date: September 7 2026


### PR DESCRIPTION
Intended for Lean users as well.