### PR TITLE
Add info for Interactive Theorem Proving in Lean tutorial

### DIFF
--- a/data/courses.yaml
+++ b/data/courses.yaml
@@ -115,6 +115,15 @@
     The goal of this workshop is to provide an 8h introduction to formal mathematics using Lean. Each 2h session combines a lecture with hands-on computer practice. Practice files for each session are provided and no prior installation of Lean is required.
   website: https://matematiflo.github.io/LeanCompactCourse/
   year: 2025
+- name: Interactive Theorem Proving in Lean
+  instructor: Florent Schaffhauser
+  institution: 18th Conference on Intelligent Computer Mathematics, Brasilia, 6-10 October 2025
+  lean_version: 4
+  tags: ['mathematics', 'dependent type theory', 'beginner']
+  summary: >
+    The goal of this tutorial is to provide a 3h introduction to formalization using Lean. The emphasis is on hands-on computer practice. Exercise files are provided and no prior installation of Lean is required.
+  website: https://matematiflo.github.io/CICM2025LeanTutorial/
+  year: 2025
 - name: Computer-assisted Mathematics
   instructor: Judith Ludwig and Florent Schaffhauser
   institution: Heidelberg University, Heidelberg (Germany)


### PR DESCRIPTION
Added a new tutorial on Interactive Theorem Proving in Lean, given at CICM 2025 in Brasilia.