### PR TITLE
feat(policy): require human-written comments on github and zulip

### DIFF
--- a/data/community.md
+++ b/data/community.md
@@ -87,6 +87,8 @@ To clarify the above: actions that can result in suspension or banning from the 
 
 This is not a free code review service. Posts that amount to 'look at my project' without a specific question or prior community involvement will be removed and the poster suspended.
 
+Please do not use an LLM when writing comments on github or Zulip. Don't worry if English is not your native language: this is true for most users; as long as you can be understood, you will be fine. Building community involves human connection; using an LLM to write for you removes this human element. Messages and comments that appear LLM-generated will be deleted, and can lead to suspension.
+
 This list is not exhaustive and the maintainers retain broad discretion in user moderation.
 
 Repeated violations will result in temporary suspensions, which will increase in length if the behavior continues. Egregious individual incidents will result in bans.

--- a/templates/contribute/index.md
+++ b/templates/contribute/index.md
@@ -63,6 +63,8 @@ change on Zulip and, when significant consensus among reviewers is reached, to o
 
 ## Use of AI
 
+Note that using an LLM when writing comments on github or Zulip is not allowed: use your own words.
+
 Using artificial intelligence tools to generate code is becoming more and more common. While this can be practical, their use also poses ethical, ecological, legal and social concerns. We recognise that there are strong differences in opinion on this topic. That said, while individual action alone will not address these concerns, we ask you to consider the effects of your AI use and if it is truly necessary.
 
 We do not accept pull requests opened by new contributors where code is LLM-generated. Mathlib intentionally has very high standards (on generality, integration with the remaining library and maintainability, including code style). As of April 2026, AI-written code fails to meet that bar by a large margin. Getting code to mathlib's standards requires understanding and writing Lean code by hand. If you just want to help and not put in the learning effort, making a PR to mathlib is counterproductive: the effort required from the mathlib maintainers is larger than the benefit, because the time used to improve the quality of the code will not result in a better quality in future PRs. More generally the reviewer team may close a PR containing low-quality code if it appears to be AI-generated. If we notice that you open several PRs without putting in this learning effort and without adhering to our community ethical standards, we retain the right of banning you both from opening new PR's and from the Zulip chat.


### PR DESCRIPTION
As discussed in the mathlib maintainers' stream [on zulip](https://leanprover.zulipchat.com/#narrow/channel/180721-mathlib-maintainers/topic/Require.20human-written.20comments.20on.20github.20and.20zulip.3F).