### PR TITLE
fix(docs): directly link to the tactic list in the menu sidebar

### DIFF
--- a/data/menus.yaml
+++ b/data/menus.yaml
@@ -26,7 +26,7 @@
     - API documentation: https://leanprover-community.github.io/mathlib4_docs
     - Declaration search (Loogle): https://loogle.lean-lang.org/
     - Language reference: https://lean-lang.org/doc/reference/latest/
-    - Tactic list: https://leanprover-community.github.io/mathlib-manual/html-multi/
+    - Tactic list: https://leanprover-community.github.io/mathlib4_docs/tactics.html
     - Glossary: glossary.html
     - Did you really prove it?: did_you_prove_it.html
     - About MWEs: mwe.html


### PR DESCRIPTION
The current link points to the mathlib manual, which points to the tactic list. Skip this level of indirection.