### PR TITLE
chore: disambiguate maintainers as mathlib maintainers

### DIFF
--- a/data/teams.yaml
+++ b/data/teams.yaml
@@ -18,7 +18,7 @@
     - Sebastian Ullrich
     - Eric Wieser
   use_biography: True
-- name: Mathlib maintainer team
+- name: Mathlib maintainers
   short_description: The mathlib maintainers have the power to approve changes and additions to mathlib. This team is responsible for the global design of mathlib, and it aims to maintain the library's coherence and keep its parts well integrated.
   description: |
     The mathlib library is under active development, with hundreds of proposed changes and additions under discussion at any time, and dozens approved every week. These proposals are structured as ["pull requests" on the mathlib Github repository](https://github.com/leanprover-community/mathlib4/pulls). The mathlib maintainers are the people who have the power to give final approval to pull requests. They must ensure mathlib has a cohesive design with a high-quality implementation.

--- a/data/teams.yaml
+++ b/data/teams.yaml
@@ -18,7 +18,7 @@
     - Sebastian Ullrich
     - Eric Wieser
   use_biography: True
-- name: Maintainer team
+- name: Mathlib maintainer team
   short_description: The mathlib maintainers have the power to approve changes and additions to mathlib. This team is responsible for the global design of mathlib, and it aims to maintain the library's coherence and keep its parts well integrated.
   description: |
     The mathlib library is under active development, with hundreds of proposed changes and additions under discussion at any time, and dozens approved every week. These proposals are structured as ["pull requests" on the mathlib Github repository](https://github.com/leanprover-community/mathlib4/pulls). The mathlib maintainers are the people who have the power to give final approval to pull requests. They must ensure mathlib has a cohesive design with a high-quality implementation.


### PR DESCRIPTION
This is already what the short description uses: make it very clear.