### PR TITLE
feat(teams): add a pointer to the cslib team

### DIFF
--- a/data/teams_intro.md
+++ b/data/teams_intro.md
@@ -1,3 +1,5 @@
 # Community teams
 
 Several teams of community members have designated responsibilities.
+Some teams are specific to [Mathlib](https://mathlib.org/), others perform activities for the broader community.
+The [CSLib project](https://cslib.io) has its own governance structure, which is documented on [its webpage](https://www.cslib.io/Governance/).


### PR DESCRIPTION
Their governance structure is more complicated than mathlib's (involving a RenPhil organisation, steering committee and maintainers). We may want to separate their decision-making from the leanprover-community's... which is why listing them as team on the webpage may not be what we want.
However, pointing to them is only appropriate; do so.