### PR TITLE
feat(teams): add a page about the moderation team

### DIFF
--- a/data/teams.yaml
+++ b/data/teams.yaml
@@ -132,9 +132,9 @@
     - Damiano Testa
     - Eric Wieser
 - name: Moderation team
-  short description: "The moderation term handles moderation of interactions [on GitHub](https://github.com/leanprover-community/) and [Zulip](https://leanprover.zulipchat.com/). This includes structural moderation (e.g., moving off-topic messages) and deleting messages violating community norms."
+  short_description: "The moderation term handles moderation of interactions [on GitHub](https://github.com/leanprover-community/) and [Zulip](https://leanprover.zulipchat.com/). This includes structural moderation (e.g., moving off-topic messages) and deleting messages violating community norms."
   description: |
-    "The moderation team handles moderation of comments and message on github (within the `leanprover-community` organisation) and [zulip](https://leanprover.zulipchat.com/). On zulip, this includes creating new private or public channels, organising existing channels and moving messages to their proper topic.  On both platforms, it entails hiding or deleting comments violating the code of conduct; users on zulip can be suspended (temporary deactivation) or banned (permanently).
+    "The moderation team handles moderation of comments and messages on github (within the `leanprover-community` organisation) and [zulip](https://leanprover.zulipchat.com/). On zulip, this includes creating new private or public channels, organising existing channels and moving messages to their proper topic.  On both platforms, it entails hiding or deleting comments violating the code of conduct; users on zulip can be suspended (temporary deactivation) or banned (permanently).
 
     The moderation team has members from mathlib, cslib and the broader Lean community. There's an informal distinction between mathlib and cslib domains: a mathlib moderator will not moderate the CSLib channel on Zulip or the cslib repository on github (and vice versa, cslib moderators's don't moderate the mathlib repositories or the mathlib channel on zulip). The current members are the following."
   use_biography: False

--- a/data/teams.yaml
+++ b/data/teams.yaml
@@ -134,9 +134,9 @@
 - name: Moderation team
   short_description: "The moderation term handles moderation of interactions [on GitHub](https://github.com/leanprover-community/) and [Zulip](https://leanprover.zulipchat.com/). This includes structural moderation (e.g., moving off-topic messages) and deleting messages violating community norms."
   description: |
-    "The moderation team handles moderation of comments and messages on github (within the `leanprover-community` organisation) and [zulip](https://leanprover.zulipchat.com/). On zulip, this includes creating new private or public channels, organising existing channels and moving messages to their proper topic.  On both platforms, it entails hiding or deleting comments violating the code of conduct; users on zulip can be suspended (temporary deactivation) or banned (permanently).
+    "The moderation team handles moderation of comments and messages on GitHub (within the `leanprover-community` organisation) and [zulip](https://leanprover.zulipchat.com/). On Zulip, this includes creating new private or public channels, organising existing channels and moving messages to their proper topic. On both platforms, it entails hiding or deleting comments violating the code of conduct; users on Zulip can be suspended (temporary deactivation) or banned (permanently).
 
-    The moderation team has members from mathlib, cslib and the broader Lean community. There's an informal distinction between mathlib and cslib domains: a mathlib moderator will not moderate the CSLib channel on Zulip or the cslib repository on github (and vice versa, cslib moderators's don't moderate the mathlib repositories or the mathlib channel on zulip). The current members are the following."
+    The moderation team has members from Mathlib, CSLib and the broader Lean community. There's an informal distinction between Mathlib and CSLib domains: a Mathlib moderator will not moderate the CSLib channel on Zulip or the cslib repository on GitHub (and vice versa, CSLib moderators's don't moderate Mathlib repositories or the mathlib channel on Zulip). The current members are the following."
   use_biography: False
   url: moderation
   members:

--- a/data/teams.yaml
+++ b/data/teams.yaml
@@ -136,7 +136,7 @@
   description: |
     "The moderation team handles moderation of comments and messages on GitHub (within the `leanprover-community` organisation) and [Zulip](https://leanprover.zulipchat.com/). On Zulip, this includes creating new private or public channels, organising existing channels and moving messages to their proper topic. On both platforms, it entails hiding or deleting comments violating the code of conduct; users on Zulip can be suspended (temporary deactivation) or banned (permanently).
 
-    The moderation team has members from Mathlib, CSLib and the broader Lean community. There's an informal distinction between Mathlib and CSLib domains: a Mathlib moderator will not moderate the CSLib channel on Zulip or the cslib repository on GitHub (and vice versa, CSLib moderators's don't moderate Mathlib repositories or the mathlib channel on Zulip). The current members are the following."
+    The moderation team has members from Mathlib, CSLib and the broader Lean community. There's an informal distinction between Mathlib and CSLib domains: a Mathlib moderator will not moderate the CSLib channel on Zulip or the cslib repository on GitHub (and vice versa, CSLib moderators don't moderate Mathlib repositories or the mathlib channel on Zulip). The current members are the following."
   use_biography: False
   url: moderation
   members:

--- a/data/teams.yaml
+++ b/data/teams.yaml
@@ -131,6 +131,52 @@
     - Wojciech Nawrocki
     - Damiano Testa
     - Eric Wieser
+- name: Moderation team
+  short description: "The moderation term handles moderation of interactions [on GitHub](https://github.com/leanprover-community/) and [Zulip](https://leanprover.zulipchat.com/). This includes structural moderation (e.g., moving off-topic messages) and deleting messages violating community norms."
+  description: |
+    "The moderation team handles moderation of comments and message on github (within the `leanprover-community` organisation) and [zulip](https://leanprover.zulipchat.com/). On zulip, this includes creating new private or public channels, organising existing channels and moving messages to their proper topic.  On both platforms, it entails hiding or deleting comments violating the code of conduct; users on zulip can be suspended (temporary deactivation) or banned (permanently).
+
+    The moderation team has members from the mathlib, cslib and broader Lean community. There's an informal distinction between mathlib and cslib domains: a mathlib moderator will not moderate the CSLib channel on Zulip or the cslib repository on github (and vice versa, cslib moderators's don't moderate the mathlib repositories or the mathlib channel on zulip). The current members are the following."
+  use_biography: False
+  url: moderation
+  members:
+    - Jeremy Avigad
+    - Anne Baanen
+    - Matthew Robert Ballard
+    - Clark Barrett
+    - Riccardo Brasca
+    - Kevin Buzzard
+    - Mario Carneiro
+    - Bryan Gin-ge Chen
+    - Johan Commelin
+    - Anatole Dedecker
+    - Rémy Degenne
+    - Leonardo de Moura
+    - Floris van Doorn
+    - Frédéric Dupuis
+    - Sébastien Gouëzel
+    - Chris Henson
+    - Julia Markus Himmel
+    - Simon Hudon
+    - Yury G. Kudryashov
+    - Robert Y. Lewis
+    - Jireh Loreaux
+    - Heather Macbeth
+    - Patrick Massot
+    - Bhavik Mehta
+    - Kyle Miller
+    - Fabrizio Montesi
+    - Kim Morrison
+    - Oliver Nash
+    - Filippo A. E. Nuccio
+    - Alexandre Rademaker
+    - Joël Riou
+    - Michael Rothgang
+    - Damiano Testa
+    - Adam Topaz
+    - Sebastian Ullrich
+    - Eric Wieser
+    - Sorrachai Yingchareonthawornchai
 - name: Code of conduct
   short_description: "This team handles incident reports and maintains community standards."
   description: "This team handles incident reports and maintains community standards. See the [community web page](https://leanprover-community.github.io/meet.html#community-guidelines)."

--- a/data/teams.yaml
+++ b/data/teams.yaml
@@ -157,7 +157,6 @@
     - Sébastien Gouëzel
     - Chris Henson
     - Julia Markus Himmel
-    - Simon Hudon
     - Yury G. Kudryashov
     - Robert Y. Lewis
     - Jireh Loreaux

--- a/data/teams.yaml
+++ b/data/teams.yaml
@@ -134,7 +134,7 @@
 - name: Moderation team
   short_description: "The moderation term handles moderation of interactions [on GitHub](https://github.com/leanprover-community/) and [Zulip](https://leanprover.zulipchat.com/). This includes structural moderation (e.g., moving off-topic messages) and deleting messages violating community norms."
   description: |
-    "The moderation team handles moderation of comments and messages on GitHub (within the `leanprover-community` organisation) and [zulip](https://leanprover.zulipchat.com/). On Zulip, this includes creating new private or public channels, organising existing channels and moving messages to their proper topic. On both platforms, it entails hiding or deleting comments violating the code of conduct; users on Zulip can be suspended (temporary deactivation) or banned (permanently).
+    "The moderation team handles moderation of comments and messages on GitHub (within the `leanprover-community` organisation) and [Zulip](https://leanprover.zulipchat.com/). On Zulip, this includes creating new private or public channels, organising existing channels and moving messages to their proper topic. On both platforms, it entails hiding or deleting comments violating the code of conduct; users on Zulip can be suspended (temporary deactivation) or banned (permanently).
 
     The moderation team has members from Mathlib, CSLib and the broader Lean community. There's an informal distinction between Mathlib and CSLib domains: a Mathlib moderator will not moderate the CSLib channel on Zulip or the cslib repository on GitHub (and vice versa, CSLib moderators's don't moderate Mathlib repositories or the mathlib channel on Zulip). The current members are the following."
   use_biography: False

--- a/data/teams.yaml
+++ b/data/teams.yaml
@@ -136,7 +136,7 @@
   description: |
     "The moderation team handles moderation of comments and message on github (within the `leanprover-community` organisation) and [zulip](https://leanprover.zulipchat.com/). On zulip, this includes creating new private or public channels, organising existing channels and moving messages to their proper topic.  On both platforms, it entails hiding or deleting comments violating the code of conduct; users on zulip can be suspended (temporary deactivation) or banned (permanently).
 
-    The moderation team has members from the mathlib, cslib and broader Lean community. There's an informal distinction between mathlib and cslib domains: a mathlib moderator will not moderate the CSLib channel on Zulip or the cslib repository on github (and vice versa, cslib moderators's don't moderate the mathlib repositories or the mathlib channel on zulip). The current members are the following."
+    The moderation team has members from mathlib, cslib and the broader Lean community. There's an informal distinction between mathlib and cslib domains: a mathlib moderator will not moderate the CSLib channel on Zulip or the cslib repository on github (and vice versa, cslib moderators's don't moderate the mathlib repositories or the mathlib channel on zulip). The current members are the following."
   use_biography: False
   url: moderation
   members:


### PR DESCRIPTION
Zulip discussion (private): https://leanprover.zulipchat.com/#narrow/channel/344977-Zulip-mods/topic/Moderation.20team.20webpage/