### PR TITLE
fix: move app token step closer to build and deploy step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,12 +24,6 @@ jobs:
     name: Build HTML
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        id: app-token
-        with:
-          app-id: ${{ secrets.LEANPROVER_COMMUNITY_WEBSITE_APP_ID }}
-          private-key: ${{ secrets.LEANPROVER_COMMUNITY_WEBSITE_PRIVATE_KEY }}
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: install Python
@@ -45,6 +39,12 @@ jobs:
 
       - name: install Python dependencies
         run: python -m pip install --upgrade pip -r requirements.txt
+
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.LEANPROVER_COMMUNITY_WEBSITE_APP_ID }}
+          private-key: ${{ secrets.LEANPROVER_COMMUNITY_WEBSITE_PRIVATE_KEY }}
 
       - name: build and deploy
         id: build


### PR DESCRIPTION
In [this run](https://github.com/leanprover-community/leanprover-community.github.io/actions/runs/27700726960/attempts/1) the `install bibtool` step took > 1h, causing the app token we minted to expire before it could be used. We reorder the steps so this won't happen anymore (and update the version of the github action while we're at it).