### PR TITLE
feat(naming): document the `₀` suffix convention

### DIFF
--- a/templates/contribute/naming.md
+++ b/templates/contribute/naming.md
@@ -557,9 +557,17 @@ The same goes for addition, subtraction, negation, powers and compositions of fu
 
 ### Groups vs groups with zero
 
-Many lemmas about `MonoidWithZero`/`GroupWithZero` have an analogous `Monoid`/`Group` lemma.
-In cases where the former name doesn't mention `zero`, it will likely conflict with the latter name.
-To disambiguate, we suffix the former name with `₀`.
+In Mathlib, we have three main series of lemmas about algebraic structures:
+1. Lemmas involving `*`, `1`, ... e.g. lemmas about multiplicative groups/monoids;
+2. Lemmas involving `+`, `0`, ... e.g. lemmas about additive groups/monoids,
+  which are usually obtained by additivising the former;
+3. Lemmas mixing both, e.g. lemmas about rings, fields, groups/monoids with zero.
+
+Series 2 and 3 are prone to clash for lemma names.
+In cases where the series 3 name doesn't mention `zero`
+(or a derived name atom, like `nonneg`, `pos`, `nonpos`, `neg`),
+it will likely conflict with the series 2 name.
+To disambiguate, we suffix the series 3 name with `₀`.
 ```
 lemma inv_eq_self {G : Type*} [Group G] [IsMulTorsionFree G] {a : G} : a⁻¹ = a ↔ a = 1
 lemma inv_eq_self₀ {K : Type*} [DivisionRing K] {a : K} : a⁻¹ = a ↔ a = -1 ∨ a = 0 ∨ a = 1

--- a/templates/contribute/naming.md
+++ b/templates/contribute/naming.md
@@ -554,3 +554,13 @@ theorem Continuous.mul (hf : Continuous f) (hg : Continuous g) : Continuous (f *
 Both theorems deserve tagging with the `fun_prop` attribute.
 
 The same goes for addition, subtraction, negation, powers and compositions of functions.
+
+### Groups vs groups with zero
+
+Many lemmas about `MonoidWithZero`/`GroupWithZero` have an analogous `Monoid`/`Group` lemma.
+In cases where the former name doesn't mention `zero`, it will likely conflict with the latter name.
+To disambiguate, we suffix the former name with `₀`.
+```
+lemma inv_eq_self {G : Type*} [Group G] [IsMulTorsionFree G] {a : G} : a⁻¹ = a ↔ a = 1
+lemma inv_eq_self₀ {K : Type*} [DivisionRing K] {a : K} : a⁻¹ = a ↔ a = -1 ∨ a = 0 ∨ a = 1
+```

--- a/templates/contribute/naming.md
+++ b/templates/contribute/naming.md
@@ -563,10 +563,10 @@ In Mathlib, we have three main series of lemmas about algebraic structures:
   which are usually obtained by additivising the former;
 3. Lemmas mixing both, e.g. lemmas about rings, fields, groups/monoids with zero.
 
-Series 2 and 3 are prone to clash for lemma names.
+Series 1 and 3 are prone to clash for lemma names.
 In cases where the series 3 name doesn't mention `zero`
 (or a derived name atom, like `nonneg`, `pos`, `nonpos`, `neg`),
-it will likely conflict with the series 2 name.
+it will likely conflict with the series 1 name.
 To disambiguate, we suffix the series 3 name with `₀`.
 ```
 lemma inv_eq_self {G : Type*} [Group G] [IsMulTorsionFree G] {a : G} : a⁻¹ = a ↔ a = 1


### PR DESCRIPTION
Many lemmas about `GroupWithZero` have an analogous `Group` lemma (and similarly for weaker/stronger typeclasses). In cases where the former name doesn't mention `zero`, it is prone to conflict with the latter. Historically, this was dealt with by priming the latter, which created a lot of primed lemmas and meant that the `AddMonoid` lemma name couldn't be inferred from the `Monoid` one automatically by `to_additive`.

A while ago, there was a push to unprime the `Group` lemmas and add the suffix `₀` to the `GroupWithZero` ones, see leanprover-community/mathlib3#9424 among others. Unfortunately that new naming convention was never recorded and wasn't applied everywhere, meaning it wasn't subsequently consistently followed.

This PR records the convention.

Pros of the convention:
* `to_additive` guesses the correct name for the `AddGroup` lemmas
* We need fewer primes overall

Cons of the convention
* The `GroupWithZero` lemma is sometimes used more than the `Group` one, but gets a longer name
* It is harder to type `₀` than `'`, in particular in the docs. This could be fixed by making `0` search for `₀`.

[Zulip discussions](https://leanprover.zulipchat.com/#narrow/channel/345428-mathlib-reviewers/topic/The.20.E2.82.80.20suffix) (in the private mathlib reviewers stream)