### PR TITLE
chore: move community guidelines to a separate page

### DIFF
--- a/data/community.md
+++ b/data/community.md
@@ -74,35 +74,6 @@ If you want to contribute to our projects then you can read our
 
 ## Community guidelines
 
-We are devoted to developing an open and accepting community
-that welcomes participation from everyone.
-Behavior that is offensive, discriminatory, or aggressive
-will not be tolerated in any form.
-We adopt the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).
-These guidelines apply to the
-[Lean Zulip chat](https://leanprover.zulipchat.com/)
-and the [leanprover-community GitHub organization](https://github.com/leanprover-community/).
-
-To clarify the above: actions that can result in suspension or banning from the Lean community Zulip include harassment, discriminatory or disrespectful behavior, sustained off-topic or disruptive posts, repeated low effort posts, use of the community to complete coursework or work tasks, use of sock-puppet accounts, DM spam, unsolicited mass DMs to users, significant use of AI without attribution, unrequested posting of "slop" AI-generated code, making unjustified and incorrect claims about AI-generated code, and ignoring moderator guidance.
-
-This is not a free code review service. Posts that amount to 'look at my project' without a specific question or prior community involvement will be removed and the poster suspended.
-
-Please do not use an LLM when writing comments on github or Zulip. Don't worry if English is not your native language: this is true for most users; as long as you can be understood, you will be fine. Building community involves human connection; using an LLM to write for you removes this human element. Messages and comments that appear LLM-generated will be deleted, and can lead to suspension.
-
-This list is not exhaustive and the maintainers retain broad discretion in user moderation.
-
-Repeated violations will result in temporary suspensions, which will increase in length if the behavior continues. Egregious individual incidents will result in bans.
-
-The [code of conduct team](/teams/coc.html) serves as first point of contact
-for reporting any concerns. You can write to members of this team directly or 
-use an [anonymous form](https://docs.google.com/forms/d/e/1FAIpQLSdEjlFqJQV65F-yzRHl-lyWAt7TSUW1axPiQK3RyV67iu1h6Q/viewform)
-to report incidents that violate the community guidelines.
-Specifically on Zulip, you can also report problematic messages to the whole
-moderation team (made of Mathlib and CSLib maintainers and some Lean FRO
-members), see the [relevant Zulip documentation](https://zulip.com/help/report-a-message).
-Only the moderators can see that you reported a message, and what you wrote in your report.
-
-We encourage a policy of de-escalation in the presence of unwelcome behavior.
-If you perceive someone acting in a way that violates our code of conduct,
-please do not respond in the same way; instead, take action to correct the behavior,
-such as reporting it to the moderators.
+By interacting on the [Lean Zulip chat](https://leanprover.zulipchat.com/)
+or any repository within the [leanprover-community GitHub organization](https://github.com/leanprover-community/),
+you agree to abide by the [community guidelines](community_guidelines.md).

--- a/data/community_guidelines.md
+++ b/data/community_guidelines.md
@@ -1,0 +1,34 @@
+# Community guidelines
+
+We are devoted to developing an open and accepting community
+that welcomes participation from everyone.
+Behavior that is offensive, discriminatory, or aggressive
+will not be tolerated in any form.
+We adopt the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).
+These guidelines apply to the
+[Lean Zulip chat](https://leanprover.zulipchat.com/)
+and the [leanprover-community GitHub organization](https://github.com/leanprover-community/).
+
+To clarify the above: actions that can result in suspension or banning from the Lean community Zulip include harassment, discriminatory or disrespectful behavior, sustained off-topic or disruptive posts, repeated low effort posts, use of the community to complete coursework or work tasks, use of sock-puppet accounts, DM spam, unsolicited mass DMs to users, significant use of AI without attribution, unrequested posting of "slop" AI-generated code, making unjustified and incorrect claims about AI-generated code, and ignoring moderator guidance.
+
+This is not a free code review service. Posts that amount to 'look at my project' without a specific question or prior community involvement will be removed and the poster suspended.
+
+Please do not use an LLM when writing comments on github or Zulip. Don't worry if English is not your native language: this is true for most users; as long as you can be understood, you will be fine. Building community involves human connection; using an LLM to write for you removes this human element. Messages and comments that appear LLM-generated will be deleted, and can lead to suspension.
+
+This list is not exhaustive and the maintainers retain broad discretion in user moderation.
+
+Repeated violations will result in temporary suspensions, which will increase in length if the behavior continues. Egregious individual incidents will result in bans.
+
+The [code of conduct team](/teams/coc.html) serves as first point of contact
+for reporting any concerns. You can write to members of this team directly or 
+use an [anonymous form](https://docs.google.com/forms/d/e/1FAIpQLSdEjlFqJQV65F-yzRHl-lyWAt7TSUW1axPiQK3RyV67iu1h6Q/viewform)
+to report incidents that violate the community guidelines.
+Specifically on Zulip, you can also report problematic messages to the whole
+moderation team (made of Mathlib and CSLib maintainers and some Lean FRO
+members), see the [relevant Zulip documentation](https://zulip.com/help/report-a-message).
+Only the moderators can see that you reported a message, and what you wrote in your report.
+
+We encourage a policy of de-escalation in the presence of unwelcome behavior.
+If you perceive someone acting in a way that violates our code of conduct,
+please do not respond in the same way; instead, take action to correct the behavior,
+such as reporting it to the moderators.


### PR DESCRIPTION
The current community page was a bit long already (anyway), and a future PR will add additional content to the guidelines (clarifying the scope of the moderation and code of conduct teams).