### PR TITLE
feat: reconcile Zulip emoji reactions on website PR messages

### DIFF
--- a/.github/workflows/bibtool.yml
+++ b/.github/workflows/bibtool.yml
@@ -29,6 +29,16 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'leanprover-community/leanprover-community.github.io'
     steps:
+      # Debug (remove with this file): show which channels the bot is subscribed
+      # to, since the reconciler only sees private channels via subscriptions.
+      - name: List bot subscriptions
+        env:
+          ZULIP_API_KEY: ${{ secrets.REPO_UPDATE_ZULIP_TOKEN }}
+        run: |
+          curl -sS -u "leanprover-community-repo-update-bot@leanprover.zulipchat.com:${ZULIP_API_KEY}" \
+            https://leanprover.zulipchat.com/api/v1/users/me/subscriptions \
+          | python3 -c 'import json,sys; [print(s["name"], "| invite_only:", s["invite_only"]) for s in json.load(sys.stdin).get("subscriptions", [])]'
+
       - name: Check out this repo's config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/bibtool.yml
+++ b/.github/workflows/bibtool.yml
@@ -37,7 +37,13 @@ jobs:
         run: |
           curl -sS -u "leanprover-community-repo-update-bot@leanprover.zulipchat.com:${ZULIP_API_KEY}" \
             https://leanprover.zulipchat.com/api/v1/users/me/subscriptions \
-          | python3 -c 'import json,sys; [print(s["name"], "| invite_only:", s["invite_only"]) for s in json.load(sys.stdin).get("subscriptions", [])]'
+          | python3 -c 'import json,sys; [print(s["name"], "| invite_only:", s["invite_only"], "| history_public_to_subscribers:", s.get("history_public_to_subscribers")) for s in json.load(sys.stdin).get("subscriptions", [])]'
+          # Can the bot see pre-subscription history in the reviewers channel?
+          curl -sS -u "leanprover-community-repo-update-bot@leanprover.zulipchat.com:${ZULIP_API_KEY}" \
+            -G https://leanprover.zulipchat.com/api/v1/messages \
+            --data-urlencode 'anchor=newest' --data-urlencode 'num_before=5' --data-urlencode 'num_after=0' \
+            --data-urlencode 'narrow=[{"operator": "channel", "operand": "mathlib reviewers"}]' \
+          | python3 -c 'import json,sys; d=json.load(sys.stdin); msgs=d.get("messages", []); print("result:", d.get("result"), d.get("msg", "")); print("visible messages:", len(msgs)); [print("-", m["subject"], "|", m["timestamp"]) for m in msgs]'
 
       - name: Check out this repo's config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/bibtool.yml
+++ b/.github/workflows/bibtool.yml
@@ -29,22 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'leanprover-community/leanprover-community.github.io'
     steps:
-      # Debug (remove with this file): show which channels the bot is subscribed
-      # to, since the reconciler only sees private channels via subscriptions.
-      - name: List bot subscriptions
-        env:
-          ZULIP_API_KEY: ${{ secrets.REPO_UPDATE_ZULIP_TOKEN }}
-        run: |
-          curl -sS -u "leanprover-community-repo-update-bot@leanprover.zulipchat.com:${ZULIP_API_KEY}" \
-            https://leanprover.zulipchat.com/api/v1/users/me/subscriptions \
-          | python3 -c 'import json,sys; [print(s["name"], "| invite_only:", s["invite_only"], "| history_public_to_subscribers:", s.get("history_public_to_subscribers")) for s in json.load(sys.stdin).get("subscriptions", [])]'
-          # Can the bot see pre-subscription history in the reviewers channel?
-          curl -sS -u "leanprover-community-repo-update-bot@leanprover.zulipchat.com:${ZULIP_API_KEY}" \
-            -G https://leanprover.zulipchat.com/api/v1/messages \
-            --data-urlencode 'anchor=newest' --data-urlencode 'num_before=5' --data-urlencode 'num_after=0' \
-            --data-urlencode 'narrow=[{"operator": "channel", "operand": "mathlib reviewers"}]' \
-          | python3 -c 'import json,sys; d=json.load(sys.stdin); msgs=d.get("messages", []); print("result:", d.get("result"), d.get("msg", "")); print("visible messages:", len(msgs)); [print("-", m["subject"], "|", m["timestamp"]) for m in msgs]'
-
       - name: Check out this repo's config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -60,3 +44,26 @@ jobs:
           dry-run: ${{ inputs.dry-run == true }}
           zulip-api-key: ${{ secrets.REPO_UPDATE_ZULIP_TOKEN }}
           github-token: ${{ github.token }}
+
+      # Debug (removed with this file): show the bot-visible tail of the
+      # reviewers channel with reactions, to verify what reconcile did. The
+      # channel has protected history, so only messages posted after the bot
+      # subscribed (2026-07-17) are visible.
+      - name: Show bot-visible messages and their reactions
+        if: always()
+        env:
+          ZULIP_API_KEY: ${{ secrets.REPO_UPDATE_ZULIP_TOKEN }}
+        run: |
+          curl -sS -u "leanprover-community-repo-update-bot@leanprover.zulipchat.com:${ZULIP_API_KEY}" \
+            -G https://leanprover.zulipchat.com/api/v1/messages \
+            --data-urlencode 'anchor=newest' --data-urlencode 'num_before=5' --data-urlencode 'num_after=0' \
+            --data-urlencode 'narrow=[{"operator": "channel", "operand": "mathlib reviewers"}]' \
+          | python3 -c '
+          import json, sys
+          d = json.load(sys.stdin)
+          print("result:", d.get("result"), d.get("msg", ""))
+          for m in d.get("messages", []):
+              reactions = ", ".join(r["emoji_name"] for r in m.get("reactions", [])) or "(none)"
+              print(f"- id={m[\"id\"]} topic={m[\"subject\"]!r} reactions: {reactions}")
+              print(f"  {m[\"content\"][:160]}")
+          '

--- a/.github/workflows/bibtool.yml
+++ b/.github/workflows/bibtool.yml
@@ -54,16 +54,17 @@ jobs:
         env:
           ZULIP_API_KEY: ${{ secrets.REPO_UPDATE_ZULIP_TOKEN }}
         run: |
-          curl -sS -u "leanprover-community-repo-update-bot@leanprover.zulipchat.com:${ZULIP_API_KEY}" \
-            -G https://leanprover.zulipchat.com/api/v1/messages \
-            --data-urlencode 'anchor=newest' --data-urlencode 'num_before=5' --data-urlencode 'num_after=0' \
-            --data-urlencode 'narrow=[{"operator": "channel", "operand": "mathlib reviewers"}]' \
-          | python3 -c '
+          cat > /tmp/show_reactions.py <<'PY'
           import json, sys
           d = json.load(sys.stdin)
           print("result:", d.get("result"), d.get("msg", ""))
           for m in d.get("messages", []):
               reactions = ", ".join(r["emoji_name"] for r in m.get("reactions", [])) or "(none)"
-              print(f"- id={m[\"id\"]} topic={m[\"subject\"]!r} reactions: {reactions}")
-              print(f"  {m[\"content\"][:160]}")
-          '
+              print(f"- id={m['id']} topic={m['subject']!r} reactions: {reactions}")
+              print("  " + m["content"][:160].replace("\n", " "))
+          PY
+          curl -sS -u "leanprover-community-repo-update-bot@leanprover.zulipchat.com:${ZULIP_API_KEY}" \
+            -G https://leanprover.zulipchat.com/api/v1/messages \
+            --data-urlencode 'anchor=newest' --data-urlencode 'num_before=5' --data-urlencode 'num_after=0' \
+            --data-urlencode 'narrow=[{"operator": "channel", "operand": "mathlib reviewers"}]' \
+          | python3 /tmp/show_reactions.py

--- a/.github/workflows/bibtool.yml
+++ b/.github/workflows/bibtool.yml
@@ -1,70 +1,33 @@
-# TEMPORARY on this branch only: workflow_dispatch resolves workflows by the
-# files registered on the default branch, so the new zulip_emoji_reconcile.yml
-# can't be dispatched until it lands on lean4. This borrows bibtool.yml's slot
-# (the least critical workflow: it only runs on PRs touching lean.bib) to test
-# the reconcile setup via
-#   gh workflow run bibtool.yml --ref zulip-emoji-reconcile [-f pr=N] [-f dry-run=false]
-# Restore the original 'check bib' workflow before merging.
-
-name: Zulip emoji reconcile (test)
+name: check bib
 
 on:
-  workflow_dispatch:
-    inputs:
-      pr:
-        description: "PR number(s), space-separated; leave empty to sweep recent messages"
-        required: false
-        default: ""
-      dry-run:
-        description: "Log planned reaction changes without writing to Zulip"
-        type: boolean
-        default: true
-
-permissions:
-  contents: read
-  pull-requests: read
+  pull_request:
+    paths:
+      - lean.bib
 
 jobs:
-  reconcile:
+  build:
+    name: Run bibtool
     runs-on: ubuntu-latest
-    if: github.repository == 'leanprover-community/leanprover-community.github.io'
     steps:
-      - name: Check out this repo's config
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          sparse-checkout: .github/zulip-emoji-config.json
-          sparse-checkout-cone-mode: false
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Reconcile
-        uses: leanprover-community/mathlib-ci/.github/actions/zulip-emoji-reconcile@20a1db8d1e1017676558fe4f5bbea77ee9f0a257
-        with:
-          config: .github/zulip-emoji-config.json
-          pr: ${{ inputs.pr }}
-          sweep: ${{ !inputs.pr }}
-          dry-run: ${{ inputs.dry-run == true }}
-          zulip-api-key: ${{ secrets.REPO_UPDATE_ZULIP_TOKEN }}
-          github-token: ${{ github.token }}
-
-      # Debug (removed with this file): show the bot-visible tail of the
-      # reviewers channel with reactions, to verify what reconcile did. The
-      # channel has protected history, so only messages posted after the bot
-      # subscribed (2026-07-17) are visible.
-      - name: Show bot-visible messages and their reactions
-        if: always()
-        env:
-          ZULIP_API_KEY: ${{ secrets.REPO_UPDATE_ZULIP_TOKEN }}
+      - name: install bibtool
         run: |
-          cat > /tmp/show_reactions.py <<'PY'
-          import json, sys
-          d = json.load(sys.stdin)
-          print("result:", d.get("result"), d.get("msg", ""))
-          for m in d.get("messages", []):
-              reactions = ", ".join(r["emoji_name"] for r in m.get("reactions", [])) or "(none)"
-              print(f"- id={m['id']} topic={m['subject']!r} reactions: {reactions}")
-              print("  " + m["content"][:160].replace("\n", " "))
-          PY
-          curl -sS -u "leanprover-community-repo-update-bot@leanprover.zulipchat.com:${ZULIP_API_KEY}" \
-            -G https://leanprover.zulipchat.com/api/v1/messages \
-            --data-urlencode 'anchor=newest' --data-urlencode 'num_before=5' --data-urlencode 'num_after=0' \
-            --data-urlencode 'narrow=[{"operator": "channel", "operand": "mathlib reviewers"}]' \
-          | python3 /tmp/show_reactions.py
+          sudo apt-get update --fix-missing
+          sudo apt-get install -y bibtool
+
+      - name: produce normalized file
+        run: |
+          bibtool --preserve.key.case=on \
+                  --preserve.keys=on \
+                  --pass.comments=on \
+                  --print.use.tab=off \
+                  -s -i lean.bib -o lean2.bib
+      - name: check diff
+        run: |
+          diff lean.bib lean2.bib || {
+            echo "::error::lean.bib is not normalized."
+            echo "::error::run 'bibtool --preserve.key.case=on --preserve.keys=on --pass.comments=on --print.use.tab=off -s -i lean.bib -o lean.bib' to fix the issue."
+            exit 1
+          }

--- a/.github/workflows/zulip_emoji_reconcile.yml
+++ b/.github/workflows/zulip_emoji_reconcile.yml
@@ -28,6 +28,15 @@ on:
     workflows: ["build site (pull request)"]
     types: [requested, completed]
 
+concurrency:
+  # Serialize all reconcile runs: the engine reads live PR state and then
+  # writes reactions, so two interleaved runs could re-assert stale state.
+  # GitHub keeps only the newest queued run per group (earlier pending runs
+  # are canceled), which is exactly right for a level-triggered tool — the
+  # last run recomputes everything and converges to the final state.
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/zulip_emoji_reconcile.yml
+++ b/.github/workflows/zulip_emoji_reconcile.yml
@@ -80,7 +80,7 @@ jobs:
         # Skip only a workflow_run whose head commit no longer maps to a PR;
         # schedule and PR-less dispatches sweep instead.
         if: steps.target.outputs.pr != '' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        uses: leanprover-community/mathlib-ci/.github/actions/zulip-emoji-reconcile@20a1db8d1e1017676558fe4f5bbea77ee9f0a257
+        uses: leanprover-community/mathlib-ci/.github/actions/zulip-emoji-reconcile@master
         with:
           config: .github/zulip-emoji-config.json
           pr: ${{ steps.target.outputs.pr }}

--- a/.github/workflows/zulip_emoji_reconcile.yml
+++ b/.github/workflows/zulip_emoji_reconcile.yml
@@ -4,10 +4,14 @@ name: Zulip emoji reconcile
 # each PR's actual state (open/closed/merged, awaiting-author, CI result), via
 # mathlib-ci's zulip-emoji-reconcile action. Repo-specific behavior lives in
 # .github/zulip-emoji-config.json.
+#
+# Event triggers give few-seconds latency on label/close/merge/CI changes; the
+# hourly sweep is the self-healing safety net that repairs anything a missed
+# event left behind.
 
 on:
   schedule:
-    - cron: "47 * * * *"   # hourly sweep as a self-healing safety net
+    - cron: "47 * * * *"   # hourly sweep (offset to dodge top-of-hour load)
   workflow_dispatch:
     inputs:
       pr:
@@ -17,7 +21,12 @@ on:
       dry-run:
         description: "Log planned reaction changes without writing to Zulip"
         type: boolean
-        default: true
+        default: false
+  pull_request_target:
+    types: [labeled, unlabeled, closed, reopened]
+  workflow_run:
+    workflows: ["build site (pull request)"]
+    types: [requested, completed]
 
 permissions:
   contents: read
@@ -28,20 +37,45 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'leanprover-community/leanprover-community.github.io'
     steps:
+      # For pull_request_target / workflow_run this checks out the lean4 branch,
+      # so the config (and everything else that runs here) is never PR-controlled.
       - name: Check out this repo's config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: .github/zulip-emoji-config.json
           sparse-checkout-cone-mode: false
 
+      - name: Determine PR number(s)
+        id: target
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+          INPUT_PR: ${{ inputs.pr }}
+          EVENT_PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          case "$EVENT" in
+            workflow_dispatch) pr="$INPUT_PR" ;;
+            pull_request_target) pr="$EVENT_PR" ;;
+            workflow_run)
+              # Resolve the PR(s) at the CI run's head commit (works for fork PRs too).
+              pr=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" \
+                     --jq 'map(.number) | join(" ")')
+              ;;
+            *) pr="" ;;  # schedule -> sweep
+          esac
+          echo "pr=${pr}" >> "$GITHUB_OUTPUT"
+
       - name: Reconcile
+        # Skip only a workflow_run whose head commit no longer maps to a PR;
+        # schedule and PR-less dispatches sweep instead.
+        if: steps.target.outputs.pr != '' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: leanprover-community/mathlib-ci/.github/actions/zulip-emoji-reconcile@20a1db8d1e1017676558fe4f5bbea77ee9f0a257
         with:
           config: .github/zulip-emoji-config.json
-          pr: ${{ inputs.pr }}
-          # Scheduled runs (no inputs) and dispatches without a PR number sweep.
-          sweep: ${{ !inputs.pr }}
-          # Scheduled sweeps always write; dispatches default to dry-run.
+          pr: ${{ steps.target.outputs.pr }}
+          sweep: ${{ !steps.target.outputs.pr }}
           dry-run: ${{ inputs.dry-run == true }}
           zulip-api-key: ${{ secrets.REPO_UPDATE_ZULIP_TOKEN }}
           github-token: ${{ github.token }}

--- a/.github/workflows/zulip_emoji_reconcile.yml
+++ b/.github/workflows/zulip_emoji_reconcile.yml
@@ -1,14 +1,13 @@
-# TEMPORARY on this branch only: workflow_dispatch resolves workflows by the
-# files registered on the default branch, so the new zulip_emoji_reconcile.yml
-# can't be dispatched until it lands on lean4. This borrows bibtool.yml's slot
-# (the least critical workflow: it only runs on PRs touching lean.bib) to test
-# the reconcile setup via
-#   gh workflow run bibtool.yml --ref zulip-emoji-reconcile [-f pr=N] [-f dry-run=false]
-# Restore the original 'check bib' workflow before merging.
+name: Zulip emoji reconcile
 
-name: Zulip emoji reconcile (test)
+# Keeps the emoji reactions on Zulip messages about this repo's PRs in sync with
+# each PR's actual state (open/closed/merged, awaiting-author, CI result), via
+# mathlib-ci's zulip-emoji-reconcile action. Repo-specific behavior lives in
+# .github/zulip-emoji-config.json.
 
 on:
+  schedule:
+    - cron: "47 * * * *"   # hourly sweep as a self-healing safety net
   workflow_dispatch:
     inputs:
       pr:
@@ -40,7 +39,9 @@ jobs:
         with:
           config: .github/zulip-emoji-config.json
           pr: ${{ inputs.pr }}
+          # Scheduled runs (no inputs) and dispatches without a PR number sweep.
           sweep: ${{ !inputs.pr }}
+          # Scheduled sweeps always write; dispatches default to dry-run.
           dry-run: ${{ inputs.dry-run == true }}
           zulip-api-key: ${{ secrets.REPO_UPDATE_ZULIP_TOKEN }}
           github-token: ${{ github.token }}

--- a/.github/zulip-emoji-config.json
+++ b/.github/zulip-emoji-config.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "Config for mathlib-ci's zulip-emoji-reconcile action: keeps the emoji reactions on Zulip messages about this repo's PRs in sync with the PR state. Messages about website PRs (posted by message_zulip_on_prs.yml to 'mathlib reviewers' > 'blog and website PRs', or anyone linking a PR) are found via the website#N linkifier / full PR URLs in message bodies. No 'pr_reviews' channel key on purpose: that channel's '#N' topics are mathlib4 PRs, not website PRs. Emoji rows mirror mathlib4's for a consistent look within the realm.",
+
+  "github_repo": "leanprover-community/leanprover-community.github.io",
+
+  "zulip": {
+    "site": "https://leanprover.zulipchat.com",
+    "email": "leanprover-community-repo-update-bot@leanprover.zulipchat.com"
+  },
+
+  "ci": {
+    "_comment": "Case-insensitive substring match against check-run name, workflow name, or status context. 'Build HTML' is the gating job of 'build site (pull request)'; 'Run bibtool' only triggers on PRs touching lean.bib, so it contributes nothing elsewhere.",
+    "check_names": ["Build HTML", "Run bibtool"]
+  },
+
+  "states": [
+    {
+      "name": "merged", "group": "pr", "priority": 30,
+      "source": {"state": "merged"}, "emoji": "merge"
+    },
+    {
+      "name": "closed", "group": "pr", "priority": 20,
+      "source": {"state": "closed"},
+      "emoji": "closed-pr", "emoji_code": "61293", "reaction_type": "realm_emoji"
+    },
+    {
+      "name": "awaiting-author", "group": "pr", "priority": 10,
+      "source": {"label": "awaiting-author"}, "emoji": "writing"
+    },
+
+    {"name": "ci-running", "group": "ci", "source": {"ci": "running"}, "emoji": "yellow"},
+    {"name": "ci-success", "group": "ci", "source": {"ci": "success"}, "emoji": "check"},
+    {"name": "ci-failure", "group": "ci", "source": {"ci": "failure"}, "emoji": "cross_mark"}
+  ]
+}


### PR DESCRIPTION
Wires up [mathlib-ci's `zulip-emoji-reconcile` action](https://github.com/leanprover-community/mathlib-ci/blob/master/docs/zulip-emoji-reconcile.md) so that Zulip messages about this repo's PRs (e.g. the ones `message_zulip_on_prs.yml` posts to *mathlib reviewers* > *blog and website PRs*) carry emoji reactions reflecting the PR's state: merged / closed / awaiting-author, plus CI status.

- `.github/zulip-emoji-config.json`: repo-specific config (emoji mirror mathlib4's). No `pr_reviews` channel key on purpose: that channel's `#N` topics are mathlib4 PRs, so website PRs are matched by URL only (the `website#N` linkifier expands to a full PR URL in rendered content).
- `.github/workflows/zulip_emoji_reconcile.yml`: event triggers for few-seconds latency — `pull_request_target` (labeled/unlabeled/closed/reopened) and `workflow_run` on "build site (pull request)" (requested/completed, PR resolved from the run's head commit) — plus an hourly sweep as the self-healing safety net and `workflow_dispatch` for manual resyncs (with a dry-run option).

Notes:
- The `leanprover-community-repo-update-bot` had to be subscribed to *mathlib reviewers* (done 2026-07-17). The channel has **protected history**, so the bot can only see messages posted after that date — older PR announcement messages will never get reactions.
- The sweep/dispatch path was tested end-to-end from this branch (via a temporary dispatch-only workflow, since removed) against this very PR's announcement message: URL matching in the private channel, `ci=running` → :yellow:, `ci=success` → swap to :check:, `awaiting-author` label add/remove → :writing: add/remove, idempotent re-runs, and human reactions (a stray :tada:) left untouched. The `pull_request_target`/`workflow_run` triggers can only fire once this lands on `lean4`; if an event misbehaves, the sweep repairs the emoji within the hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)