### PR TITLE
Make the lean3 warning even more obvious, and strikethrough write-access docs

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -47,15 +47,15 @@
 <div id="mainbox">
 
   <main>
-    <div class="alert alert-warning">
+    <div class="alert alert-danger" style="background: #b00020; color: white; position: sticky; top: 0;">
       <p>
-      This webpage is about Lean 3, which is <strong>effectively obsolete</strong>;
+      This webpage is about Lean 3, which is <u>effectively obsolete</u>;
       the community has migrated to Lean 4.
       </p>
       {% if name is defined %}
       <p>
       Jump to the
-      <a href="https://leanprover-community.github.io/{% if name.endswith('.md') %}{{ name[:-3] }}.html{% else %}{{ name }}{% endif %}">corresponding page</a>
+      <a href="https://leanprover-community.github.io/{% if name.endswith('.md') %}{{ name[:-3] }}.html{% else %}{{ name }}{% endif %}" style="color: #88ccff;">corresponding page</a>
       on the main Lean 4 website.
       </p>
       {% endif %}

--- a/templates/contribute/index.md
+++ b/templates/contribute/index.md
@@ -14,7 +14,7 @@ Once you have code that you'd like to contribute, you should open a PR.
 There is a [video tutorial](https://www.youtube.com/watch?v=Bnc8w9lxe8A) walking you through the process of making a PR on YouTube.
   
 ## Making a Pull Request (PR)
-3. Introduce yourself on Zulip and ask for write access to non-master branches of the mathlib repository. Please include your GitHub username in your request. Make your changes on a branch of the main repository.
+3. ~~Introduce yourself on Zulip and ask for write access to non-master branches of the mathlib repository. Please include your GitHub username in your request. Make your changes on a branch of the main repository.~~ (this is outdated, please ignore)
    
 4. If you've made a lot of changes/additions, try to make many PRs containing small, self-contained pieces. This helps you get feedback as you go along, and it is much easier to review. This is especially important for new contributors.
 5. The title of the PR should follow our [commit conventions](https://github.com/leanprover-community/lean/blob/master/doc/commit_convention.md).

--- a/templates/contribute/index.md
+++ b/templates/contribute/index.md
@@ -14,7 +14,7 @@ Once you have code that you'd like to contribute, you should open a PR.
 There is a [video tutorial](https://www.youtube.com/watch?v=Bnc8w9lxe8A) walking you through the process of making a PR on YouTube.
   
 ## Making a Pull Request (PR)
-3. ~~Introduce yourself on Zulip and ask for write access to non-master branches of the mathlib repository. Please include your GitHub username in your request. Make your changes on a branch of the main repository.~~ (this is outdated, please ignore)
+3. ~~Introduce yourself on Zulip and ask for write access to non-master branches of the mathlib repository. Please include your GitHub username in your request. Make your changes on a branch of the main repository.~~ (Note as of 2026: this information is outdated and should be ignored; mathlib4 now uses a typical fork model.)
    
 4. If you've made a lot of changes/additions, try to make many PRs containing small, self-contained pieces. This helps you get feedback as you go along, and it is much easier to review. This is especially important for new contributors.
 5. The title of the PR should follow our [commit conventions](https://github.com/leanprover-community/lean/blob/master/doc/commit_convention.md).


### PR DESCRIPTION
Followup to #377

This uses the same red color from the [mathlib3 docs](https://leanprover-community.github.io/mathlib_docs/) (just `alert-danger` isn't as prominent), and makes the banner stick to the top to prevent people with section links from missing it.

Also strikethrough the write-access note in the [mathlib3 contribution guide](https://leanprover-community.github.io/lean3/contribute/index.html), and add a note to clarify it is outdated.

Before:
<img height="300" alt="image" src="https://github.com/user-attachments/assets/6fdf717e-6502-44fe-ae15-dc6d4c238f3d" />
After:
<img height="300" alt="image" src="https://github.com/user-attachments/assets/55b51666-0f2b-404e-b04f-900c17caa757" />


[#mathlib4 > github write access](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/github.20write.20access/with/612455049)