### PR TITLE
Add "Bridging the LMFDB and Lean" workshop (MIT, Jan 25-29 2027)

### DIFF
--- a/data/events.yaml
+++ b/data/events.yaml
@@ -75,6 +75,13 @@
   location: University of East Anglia, Norwich, UK
   type: workshop
 
+- title: "Bridging the LMFDB and Lean"
+  url: https://math.mit.edu/~roed/conferences/lean-lmfdb2/
+  start_date: January 25 2027
+  end_date: January 29 2027
+  location: MIT, Cambridge, MA, USA
+  type: workshop
+
 - title: "Techniques and Tools for the Formalization of Analysis"
   url: https://icerm.brown.edu/program/topical_workshop/tw-26-ttfa
   start_date: May 11 2026


### PR DESCRIPTION
Adds an upcoming event to `data/events.yaml`:

**Bridging the LMFDB and Lean** — MIT, Cambridge, MA, USA, January 25–29, 2027
<https://math.mit.edu/~roed/conferences/lean-lmfdb2/>

This is the second workshop in the "Scalable Theorem Proving via Mathematical Databases" series (funded by the AI for Math Fund), following ["Bridging Lean and the LMFDB"](https://multramate.github.io/lean-lmfdb) at the University of East Anglia in June/July 2026, which is already listed. The plan is to continue developing Lean tactics and certificates for proving the correctness of LMFDB data, alongside tutorials and collaborative formalization projects.

Organized by David Roe and Andrew Sutherland. Applications are open until September 30, 2026, with some funding available for early career researchers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)