### PR TITLE
ci: sync the lean3 site deploy workflow with lean4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,18 +7,30 @@ on:
       - 'oldsite'
   schedule:
     - cron: '0 4 * * *'
+  workflow_dispatch:
+
+concurrency:
+  # label each workflow run; only the latest with each label will run
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # if there is a run in progress with the same label, the next new run will be queued
+  # and new runs after that will cancel pending runs
+  cancel-in-progress: false
+
+permissions:
+  contents: write
 
 jobs:
   build:
     name: Build HTML
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: install Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: 3.8
+          # TODO: fix things so we can build with 3.12 and above
+          python-version: 3.11
 
       - name: install bibtool
         run: |
@@ -28,12 +40,28 @@ jobs:
       - name: install Python dependencies
         run: python -m pip install --upgrade pip -r requirements.txt
 
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.LEANPROVER_COMMUNITY_WEBSITE_APP_ID }}
+          private-key: ${{ secrets.LEANPROVER_COMMUNITY_WEBSITE_PRIVATE_KEY }}
+
       - name: build and deploy
-        run:
+        id: build
+        run: |
           ./deploy.sh
         env:
           git_hash: ${{ github.sha }}
-          DEPLOY_GITHUB_TOKEN: ${{ secrets.MASTER_DEPLOY }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          DEPLOY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           DEPLOY_GITHUB_USER: leanprover-community-bot
           github_repo: ${{ github.repository }}
           github_ref: ${{ github.ref  }}
+
+      - name: Upload artifact
+        id: upload-artifact
+        if: ${{ !cancelled() && (steps.build.outcome == 'success') }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: site
+          path: build/


### PR DESCRIPTION
#891 made changes to the `lean3` branch but failed to deploy. We copy over the `lean4` build workflow (omitting unneeded secrets).

Prepared with Claude code.