### PR TITLE
Add Lean Refactor Arena workshop details

### DIFF
--- a/data/events.yaml
+++ b/data/events.yaml
@@ -11,6 +11,13 @@
   location: Berkeley, CA, USA
   type: workshop
 
+- title: "Lean Refactor Arena"
+  url: https://leanrefactor.github.io/
+  start_date: August 26 2026
+  end_date: December 12 2026
+  location: Atlanta, USA
+  type: workshop
+
 - title: "Lean Focus Week"
   url: https://bristol-lean.github.io/blue/events/
   start_date: October 26 2026


### PR DESCRIPTION
Add the NeurIPS 2026 workshop on “AI for Verifiable Coding” (https://vericodegen.github.io/) and the associated competition track on Lean Refactoring (https://leanrefactor.github.io/).

This workshop & competition have been sponsored by Harmonic.fun, with more sponsors to come.
This event is also reposted on LinkedIn by Lean FRO and others (e.g., https://lnkd.in/p/g2MBzRdG).