### PR TITLE
feat: add documentation about cross-reference tags

### DIFF
--- a/templates/contribute/commit.md
+++ b/templates/contribute/commit.md
@@ -85,7 +85,7 @@ Fix a typo, add two periods.
 An example with dependent PRs:
 
 ```markdown
-feat: The norm on `Unitization` is a C⋆-norm
+feat: the norm on `Unitization` is a C⋆-norm
 
 This shows that C⋆-algebras are always `RegularNormedAlgebra`s, so that their `Unitization` is equipped with a norm. Moreover, we show this norm is a C⋆-norm.
 

--- a/templates/contribute/doc.md
+++ b/templates/contribute/doc.md
@@ -266,6 +266,14 @@ We follow [Euclid's *Elements* [Prop. 1]][heath1956a].
 
 > We follow [Euclid's *Elements* [Prop. 1]][heath1956a].
 
+## Cross-references to external mathematical databases
+
+Declarations that appear in an external database can be tagged with a cross-reference
+attribute, such as `@[stacks 0123]` or `@[wikidata Q12345]`, which is then rendered as a link to the database item in the declaration's auto-generated documentation entry. Attributes also accepts an optional comment, as in
+`@[stacks 0123 "only the first part is formalized"]`. See
+[the cross-reference attributes docs page](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Tactic/CrossRefAttribute.html#Cross-reference-attributes)
+for the databases currently supported and the identifier format each one expects. 
+
 ## Language
 
 Documentation should be written in English.


### PR DESCRIPTION
To the best of my knowledge, these weren't really documented anywhere, despite the facts that we now have a half dozen databases and hundreds of tags (mostly stacks but nevermind...). This seemed like the most sensible location.