### PR TITLE
ci: make the site's build location configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,25 @@ The website relies on several components which are built in other repositories:
   Use option `--reload` to continuously build when templates are
   changed (this won't work for watching changes in `data/`).
 
+Three environment variables control where the site is built and where it
+expects to be served from. All of them default to the values this repository
+deploys with, so a normal build needs none of them:
+
+* `SITE_TARGET`: output directory (default `build/`).
+* `SITE_BASE_URL`: the URL the site will be served from, with a trailing slash
+  (default `https://leanprover-community.github.io/`). Every internal link is
+  built by appending to it, so setting it relocates the whole site. It is
+  ignored when `--local` is passed, which derives a `file://` url from
+  `SITE_TARGET` instead.
+* `SITE_EDIT_BASE`: prefix for the "Suggest edits to this page on GitHub"
+  footer link, which points at the templates rather than at the built site
+  (default the `templates/` directory of the `lean4` branch of this repo).
+
+Note that links to the other leanprover-community GitHub Pages sites
+(`mathlib4_docs`, `mathlib_stats`, `blog`, ...) are deliberately absolute:
+those are separate repositories that only happen to be served next to this
+site, so they must not move with `SITE_BASE_URL`.
+
 
 If you want to retrieve the list of Zulip users to get the users map, the
 environment variable `ZULIP_KEY` should be set with the Zulip API key of the

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ expects to be served from. All of them default to the values this repository
 deploys with, so a normal build needs none of them:
 
 * `SITE_TARGET`: output directory (default `build/`).
-* `SITE_BASE_URL`: the URL the site will be served from, with a trailing slash
+* `SITE_BASE_URL`: the URL the site will be served from
   (default `https://leanprover-community.github.io/`). Every internal link is
-  built by appending to it, so setting it relocates the whole site. It is
-  ignored when `--local` is passed, which derives a `file://` url from
-  `SITE_TARGET` instead.
+  built by appending to it, so setting it relocates the whole site; a trailing
+  slash is added if missing. It is ignored when `--local` is passed, which
+  derives a `file://` url from `SITE_TARGET` instead.
 * `SITE_EDIT_BASE`: prefix for the "Suggest edits to this page on GitHub"
   footer link, which points at the templates rather than at the built site
   (default the `templates/` directory of the `lean4` branch of this repo).

--- a/data/menus.yaml
+++ b/data/menus.yaml
@@ -2,7 +2,7 @@
   items:
     - Zulip chat: https://leanprover.zulipchat.com/
     - GitHub: https://github.com/leanprover-community/mathlib4
-    - Blog: blog
+    - Blog: https://leanprover-community.github.io/blog
     - Community information: meet.html
     - Community guidelines: community_guidelines.html
     - Teams: teams.html

--- a/make_site.py
+++ b/make_site.py
@@ -98,6 +98,15 @@ ROOT = Path(__file__).parent
 DATA = ROOT/'data'
 TEMPLATE_SRC = str(ROOT/'templates')
 
+# Where the built site will be served from, and where the templates it is built
+# from live. These are overridable from the environment (SITE_TARGET,
+# SITE_BASE_URL, SITE_EDIT_BASE) so that this site can be built for somewhere
+# other than https://leanprover-community.github.io/ without patching the
+# script. All internal links are formed by appending to base_url, so pointing
+# it elsewhere relocates the whole site.
+DEFAULT_BASE_URL = 'https://leanprover-community.github.io/'
+DEFAULT_EDIT_BASE = 'https://github.com/leanprover-community/leanprover-community.github.io/blob/lean4/templates/'
+
 @dataclass
 class MenuItem:
     title: str
@@ -852,9 +861,11 @@ class LeanSite(Site):
     def template_names(self) -> List[str]:
         return self.env.list_templates(filter_func=lambda s: self.is_template(s) and self.template_filter(s))
 
-def render_site(target: Path, base_url: str, reloader=False, only: Optional[str] = None):
+def render_site(target: Path, base_url: str, edit_base: str = DEFAULT_EDIT_BASE,
+                reloader=False, only: Optional[str] = None):
     default_context = lambda: {
             'base_url': base_url,
+            'edit_base': edit_base,
             'menus': menus,
             }
     target.mkdir(parents=True, exist_ok=True)
@@ -950,7 +961,8 @@ def render_site(target: Path, base_url: str, reloader=False, only: Optional[str]
     for team in teams:
         extra = {'reviewer_data': reviewer_data} if team.url == 'reviewers' else {}
         with (target/'teams'/(team.url + '.html')).open('w') as tgt_file:
-            team_tpl.stream(team=team, menus=menus, base_url=base_url, **extra).dump(tgt_file)
+            team_tpl.stream(team=team, menus=menus, base_url=base_url,
+                            edit_base=edit_base, **extra).dump(tgt_file)
 
 
     for folder in ['css', 'js', 'img', 'papers', str(target/'teams')]:
@@ -965,8 +977,10 @@ if __name__ == '__main__':
         only = sys.argv[sys.argv.index('--only')+1]
     except:
         only = None
+    target = Path(os.environ.get('SITE_TARGET') or ROOT/'build')
     if '--local' in sys.argv:
-        base_url = f"file://{(Path(__file__).parent/'build').absolute()}/"
+        base_url = f"file://{target.absolute()}/"
     else:
-        base_url = 'https://leanprover-community.github.io/'
-    render_site(ROOT/'build', base_url, reloader='--reload' in sys.argv, only=only)
+        base_url = os.environ.get('SITE_BASE_URL') or DEFAULT_BASE_URL
+    edit_base = os.environ.get('SITE_EDIT_BASE') or DEFAULT_EDIT_BASE
+    render_site(target, base_url, edit_base, reloader='--reload' in sys.argv, only=only)

--- a/make_site.py
+++ b/make_site.py
@@ -863,6 +863,10 @@ class LeanSite(Site):
 
 def render_site(target: Path, base_url: str, edit_base: str = DEFAULT_EDIT_BASE,
                 reloader=False, only: Optional[str] = None):
+    # Internal links are formed as base_url + path, where path never starts with
+    # a slash, so base_url must end with exactly one. Guarding here means a
+    # SITE_BASE_URL given without a trailing slash still produces valid links.
+    base_url = base_url.rstrip('/') + '/'
     default_context = lambda: {
             'base_url': base_url,
             'edit_base': edit_base,
@@ -880,7 +884,7 @@ def render_site(target: Path, base_url: str, edit_base: str = DEFAULT_EDIT_BASE,
 
     def get_contents(template):
         src = Path(template.filename).read_text(encoding='utf-8').replace('img/',
-                base_url+'/img/')
+                base_url+'img/')
         src = re.sub(r'\{%-?\s*raw\s*-?%\}', '', src)
         src = re.sub(r'\{%-?\s*endraw\s*-?%\}', '', src)
         doc = Document(src)

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -67,7 +67,7 @@
   <nav class="footer navbar navbar-expand-lg navbar-light bg-light justify-content-end">
   <ul class="nav">
     <li class="nav-item">
-      <a class="nav-link active" href="https://github.com/leanprover-community/leanprover-community.github.io/blob/lean4/templates/{{ name }}">Suggest edits to this page on GitHub</a>
+      <a class="nav-link active" href="{{ edit_base }}{{ name }}">Suggest edits to this page on GitHub</a>
     </li>
   </ul>
   </nav>

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -5,9 +5,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-  <link rel="stylesheet" href="{{base_url}}/css/lean.css" >
-  <link rel="shortcut icon" href="{{base_url}}/img/favicon.ico">
-  <link rel="search" type="application/opensearchdescription+xml" title="mathlib docs" href="{{base_url}}/opensearch.xml">
+  <link rel="stylesheet" href="{{base_url}}css/lean.css" >
+  <link rel="shortcut icon" href="{{base_url}}img/favicon.ico">
+  <link rel="search" type="application/opensearchdescription+xml" title="mathlib docs" href="{{base_url}}opensearch.xml">
   <link href="https://fonts.googleapis.com/css2?family=Merriweather&family=Open+Sans&family=Source+Code+Pro:wght@400;600&display=swap" rel="stylesheet">
     {% block extracss %}{% endblock %}
 
@@ -75,7 +75,7 @@
     <script src="https://code.jquery.com/jquery-3.5.1.min.js"
       integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
       crossorigin="anonymous"></script>
-    <script src="{{ base_url }}/js/bootstrap.min.js"></script>
+    <script src="{{ base_url }}js/bootstrap.min.js"></script>
     <script type="module">
       import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
       mermaid.initialize({ startOnLoad: true });

--- a/templates/mathlib_stats.html
+++ b/templates/mathlib_stats.html
@@ -43,7 +43,7 @@
 
 <p>
   A visualization showing how the various topics in mathlib interact and their
-  relative sizes can be found <a href="{{ base_url }}/mathlib4_docs/mathlib.html">here</a>.
+  relative sizes can be found <a href="https://leanprover-community.github.io/mathlib4_docs/mathlib.html">here</a>.
 </p>
 
 {% endblock %}
@@ -56,7 +56,7 @@
 <script type="text/javascript" src="https://unpkg.com/tabulator-tables@4.6.2/dist/js/tabulator.min.js"></script>
 
 
-<script type="text/javascript" src="{{ base_url }}mathlib_stats/gitstats4.js"></script>
+<script type="text/javascript" src="https://leanprover-community.github.io/mathlib_stats/gitstats4.js"></script>
 <script>
   // because both gitstats files use the same variable names, rename the mathlib4 ones before importing the mathlib3 ones
   const gen_date4 = gen_date;
@@ -69,7 +69,7 @@
   const files_by_date4 = files_by_date;
   const lines_by_date4 = lines_by_date;
 </script>
-<script type="text/javascript" src="{{ base_url }}/mathlib_stats/gitstats.js"></script>
+<script type="text/javascript" src="https://leanprover-community.github.io/mathlib_stats/gitstats.js"></script>
 
 <script>
   const color = Chart.helpers.color;

--- a/templates/opensearch.xml
+++ b/templates/opensearch.xml
@@ -4,5 +4,5 @@
   <Description>Search mathlib docs</Description>
   <InputEncoding>UTF-8</InputEncoding>
   <Image width="16" height="16" type="image/x-icon">{{base_url}}/img/favicon.ico</Image>
-  <Url type="text/html" method="GET" template="{{base_url}}/mathlib_docs/find/{searchTerms}" />
+  <Url type="text/html" method="GET" template="https://leanprover-community.github.io/mathlib_docs/find/{searchTerms}" />
 </OpenSearchDescription>

--- a/templates/opensearch.xml
+++ b/templates/opensearch.xml
@@ -3,6 +3,6 @@
   <ShortName>mathlib</ShortName>
   <Description>Search mathlib docs</Description>
   <InputEncoding>UTF-8</InputEncoding>
-  <Image width="16" height="16" type="image/x-icon">{{base_url}}/img/favicon.ico</Image>
+  <Image width="16" height="16" type="image/x-icon">{{base_url}}img/favicon.ico</Image>
   <Url type="text/html" method="GET" template="https://leanprover-community.github.io/mathlib_docs/find/{searchTerms}" />
 </OpenSearchDescription>


### PR DESCRIPTION
Add three environment variables, each defaulting to what this repository already deploys with, so that the site can be built for a location other than https://leanprover-community.github.io/ without patching make_site.py:

* `SITE_TARGET`: output directory (default build/)
* `SITE_BASE_URL`: the URL the site will be served from; every internal link is formed by appending to it, so setting it relocates the whole site
* `SITE_EDIT_BASE`: prefix for the "Suggest edits to this page on GitHub" footer link, which points at the templates rather than at the built site

Five links were built relative to `base_url` but actually point at *other* `leanprover-community` GitHub Pages sites, which only happen to be served next to this one; they would 404 if the site moved. Make them absolute: `mathlib4_docs` and `mathlib_stats` (in `mathlib_stats.html`), `mathlib_docs` (in `opensearch.xml`), and the blog (in `menus.yaml`).