### PR TITLE
add paper on "Formalizing Soundness Proofs of Linear PCP SNARKs" to bib.lean

### DIFF
--- a/lean.bib
+++ b/lean.bib
@@ -232,6 +232,20 @@
   tags          = {formalization, lean3}
 }
 
+@InProceedings{   BaileyMiller24,
+  author        = {Bolton Bailey and Andrew Miller},
+  title         = {Formalizing Soundness Proofs of Linear {PCP} {SNARKs}},
+  booktitle     = {33rd USENIX Security Symposium (USENIX Security 24)},
+  year          = {2024},
+  isbn          = {978-1-939133-44-1},
+  address       = {Philadelphia, PA},
+  pages         = {1489--1506},
+  url           = {https://www.usenix.org/conference/usenixsecurity24/presentation/bailey},
+  publisher     = {USENIX Association},
+  month         = {Aug},
+  tags          = {formalization, lean3, lean4}
+}
+
 @InProceedings{   BasoldBruinLawson24,
   author        = {Basold, Henning and Bruin, Peter and Lawson, Dominique},
   title         = {{The Directed Van Kampen Theorem in Lean}},


### PR DESCRIPTION
This PR adds [a paper I wrote](https://www.usenix.org/system/files/usenixsecurity24-bailey.pdf) with my advisor in Lean. 