### PR TITLE
Guidance on breaking changes

### DIFF
--- a/templates/contribute/how-to-contribute.md
+++ b/templates/contribute/how-to-contribute.md
@@ -73,6 +73,10 @@ Once you're happy with your local changes, it's time to make a pull request to t
   This helps you get feedback as you go along, and it is much easier to review.
   This is especially important for new contributors as it prevents wasted effort.
 
+* Avoid making *breaking* changes, i.e. PRs that make downstream code go from _working_ to _giving an error_.
+  However, this kind of change is sometimes necessary for the growth of mathlib, but should be carefully considered.
+  In these situations, the change must be mentioned in the PR description, and a mitigation or fix provided there also.
+
 * The title and description of the PR should follow our [commit conventions](commit.html).
 
 * If you are moving or deleting declarations, please include these lines at the bottom of the commit message

--- a/templates/contribute/style.md
+++ b/templates/contribute/style.md
@@ -849,6 +849,8 @@ also properly tagged with `to_additive`, like so:
 
 We allow, but discourage, contributors from simultaneously renaming declarations X to Y and W to X.
 In this case, no deprecation attribute is required for X, but it is for W.
+Similarly, we discourage contributors from simultaneously renaming declarations from X to Y and "recycling" the name X for a new lemma.
+In both of these situations, the rename *must* be mentioned explicitly in the PR description, together with its motivation.
 
 Named instances do not require deprecations. Deprecated declarations can be deleted after 6 months.
 


### PR DESCRIPTION
The motivation here is that:
1. Users bumping their mathlib versions by a small amount (eg less than one month) should not have to deal with errors in their code
2. But if this is necessary, then mathlib should endeavour to make them as easy to fix as possible
3. We already follow these principles with the deprecation policy and deprecation of modules policy
4. Ecosystems of programming languages are often very strict with breaking changes, and the guidance I add here is relatively very mild to the contributor and harsh on the downstream user. I don't like that it's this way round, but hopefully the change here is a step in the right direction and uncontroversially so. (see eg Rust's policy on breaking changes https://rustc-dev-guide.rust-lang.org/bug-fix-procedure.html, or SemVer's rule on backwards-incompatible changes https://semver.org/#spec-item-8)
5. Lean core sets an expectation that breaking changes will be discussed in the release notes: https://github.com/leanprover/lean4/blob/master/RELEASES.md
6. A number of PRs already discuss breaking changes in their description
7. Hopscotch and its existing CI workflows create issues/PRs giving the mathlib commit and PR description which breaks project code, so requiring it to be mentioned in the description is especially useful for users of hopscotch.

The spirit of this policy already exists in mathlib writings in various guises:
- We discourage non-terminal `simp`s because they make it more likely that a new `[simp]` can produce a breaking change (and more generally the flexible linter)
- We have a deprecation policy for names and modules
- The "Growing Mathlib" paper says
> Many large formalisation projects are carried out in a repository depending on Mathlib. If keeping
up with the latest Mathlib changes is too onerous, contributing results back to Mathlib may become impossible.

Previous discussion on related points:
- https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Deprecation.20.26.20recycling.20lemma.20names
- [#mathlib4 > notes for adaptations each release cycle @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/notes.20for.20adaptations.20each.20release.20cycle/near/423830209)
- [#mathlib maintainers > Deleting #align statements @ 💬](https://leanprover.zulipchat.com/#narrow/channel/180721-mathlib-maintainers/topic/Deleting.20.23align.20statements/near/427529045) in particular the comment

> Imagine that refactor PRs have to pass a check that every unique id is accounted for by mentioning which are added and which are deleted in the PR description. Then as a reviewer you can know if every declaration has been preserved (modulo judgment calls for whether to preserve an id for a transformed statement).
> Adding what you just said, it could also check that the id refers to the same statement, and if not, the PR description must mention the breaking change.

- [#lean4 > Deprecation without explanations @ 💬](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Deprecation.20without.20explanations/near/406459828)
- The general discussion around deprecated modules